### PR TITLE
ci: trigger release on v* tags, fix yarn-based build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release app
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 jobs:
   build:
     strategy:
@@ -19,8 +22,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
       - name: Publish app
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: npm run publish
+        run: yarn run publish


### PR DESCRIPTION
## Summary
- Trigger release workflow on `v*` tag pushes (in addition to manual dispatch)
- Switch from `npm install` to `yarn install --frozen-lockfile` to match local dev and avoid the eslint peer-dep ERESOLVE that broke the v3.0.0 run
- Run `yarn build` (electron-vite build) before `electron-builder --publish always` so the `out/` artifacts exist

## Test plan
- [ ] PR CI green
- [ ] After merge, push a tag (or re-tag v3.0.0) and confirm the workflow runs and uploads artifacts to a GitHub release