### PR TITLE
ci: bump release workflow to Node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
## Summary
- Bump CI Node from 20 to 22 — \`@electron/rebuild@4.0.4\` requires \`>=22.12.0\`, which broke the v3.0.0 tag run on all three OSes during \`yarn install\`.

## Test plan
- [ ] PR CI green
- [ ] Re-tag v3.0.0 after merge to retry the release