### PR TITLE
ci: use built-in GITHUB_TOKEN for release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: write
 jobs:
   build:
     strategy:
@@ -28,6 +30,6 @@ jobs:
         run: yarn build
       - name: Publish app
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn run publish


### PR DESCRIPTION
## Summary
- Replace the expired \`GH_TOKEN\` secret with the auto-provisioned \`GITHUB_TOKEN\`
- Add \`permissions: contents: write\` so the token can create/upload releases

The v3.0.0 build completed successfully on all OSes; only the upload step failed with \`401 Unauthorized\` against \`GET /repos/jcalado/cgtimer/releases\`. Using the built-in token removes the PAT-rotation footgun.

## Test plan
- [ ] PR CI green
- [ ] Re-tag v3.0.0 and confirm artifacts upload to a GitHub release