### PR TITLE
Control room integrations: AMCP health, X32 audio, variable tiles, Companion feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ wiki — [code@jcalado.com](mailto:code@jcalado.com).
 | Playback    | Next Clip               | Clip cued via `LOADBG`; flashes `NOT CUED` as the playing clip ends  |
 | Playback    | Clip Progress           | Progress bar for the playing clip                                    |
 | Playback    | Channel Format          | Video mode and framerate of the CasparCG channel                     |
+| Playback    | Server Health           | CasparCG AMCP connection, version and round-trip latency             |
 | Timers      | Time-of-day Countdown   | Counts down to a target `HH:MM:SS`                                   |
 | Timers      | OSC Timer               | Named stopwatch driven by `/timer/{name}/...` OSC commands           |
 | Ontime      | Ontime Timer            | Mirrors `timer.current`                                              |
@@ -67,6 +68,9 @@ wiki — [code@jcalado.com](mailto:code@jcalado.com).
 | Recorders   | HyperDeck Recorder      | Live status + record timecode for a Blackmagic HyperDeck             |
 | Recorders   | HyperDeck Media         | Remaining record capacity on a HyperDeck's active slot               |
 | Recorders   | All Recorders           | `n/m REC` rollup across every HyperDeck, with offline warning        |
+| Audio       | X32 Channel             | Mute state and name of an X32/M32 input channel                      |
+| Audio       | X32 Meter               | Live input level meter (dB scale) for an X32/M32 channel             |
+| Utility     | Variable Tile           | Shows any value pushed to `/display/{key}` over OSC                  |
 
 ## Configuration
 
@@ -76,6 +80,49 @@ Press `Alt` to reveal the menu, or `Cmd`/`Ctrl + ,` to jump straight to
 **Preferences**. From there you can configure the OSC port and CasparCG
 channel, pick the display, set default colors, and manage your timezones
 and HyperDecks.
+
+### CasparCG connection (AMCP)
+
+Setting a **Server address** in Preferences opens an AMCP connection
+(TCP/5250 by default) that powers the Server Health widget: reachability,
+server version, and round-trip latency via `PING`. On CasparCG 2.4+ the
+connection also issues `OSC SUBSCRIBE`, so the server streams OSC to
+CGTimer with no `casparcg.config` changes. Older servers refuse the
+command; the health widget then shows a `NO OSC PUSH` badge and you
+configure the OSC target in `casparcg.config` as before. Leaving the
+address empty disables the AMCP client entirely; OSC listening works
+as always.
+
+### Variable tiles
+
+Any OSC sender can drive a **Variable Tile** by sending
+`/display/{key} <value>` to CGTimer's OSC port; sending the address with
+no arguments clears the tile. In Bitfocus Companion, add a generic OSC
+instance pointed at CGTimer and a trigger like "on variable change, send
+`/display/cam1 $(atem:input_1_name)`", and the tile becomes a live
+readout for that variable. Arguments are joined with spaces, so multiple
+values in one message work too.
+
+### Companion feedback
+
+Layouts are switchable from a Stream Deck by sending `/layout/load "Show A"`
+from a Companion Generic OSC instance. To make the buttons light up with the
+active layout, set the Companion address in **Preferences → Companion**:
+CGTimer then pushes the active layout name to Companion's inbound OSC API
+(`/custom-variable/cgtimer_layout/value`, port 12321 by default) on every
+switch, on startup, and every 10 s as a keepalive. Create the custom
+variable in Companion under **Variables → Custom**, then give each layout
+button a **Check variable value** feedback comparing it to that button's
+layout name. CGTimer also emits a generic `/layout/active "Show A"` to the
+same target for non-Companion consumers.
+
+### X32 / M32 mixer
+
+Set the console address in **Preferences → Mixer** (OSC port 10023 by
+default) to enable the X32 widgets. CGTimer subscribes with `/xremote`
+and `/meters` and renews automatically; channel names, mute states and
+fader levels come straight from the desk, so relabeling a channel on the
+console updates the dashboard.
 
 ### Layout editor
 

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -406,6 +406,26 @@ function App() {
     ccgBackgroundCued: false,
     ccgFormat: "",
     ccgFramerate: 0,
+    displayValues: {} as Record<string, string>,
+    casparcg: {
+      enabled: false,
+      connected: false,
+      lastError: null as string | null,
+      version: "",
+      latencyMs: null as number | null,
+      oscSubscribed: null as boolean | null,
+    },
+    x32: {
+      enabled: false,
+      connected: false,
+      channels: [] as Array<{
+        index: number;
+        name: string;
+        on: boolean;
+        fader: number;
+        meter: number;
+      }>,
+    },
     elapsedColor: "",
     remainingColor: "",
     clockColor: "",
@@ -610,6 +630,20 @@ function App() {
         ccgBackgroundCued: false,
         ccgFormat: "",
         ccgFramerate: 0,
+        displayValues: {},
+        casparcg: {
+          enabled: false,
+          connected: false,
+          lastError: null,
+          version: "",
+          latencyMs: null,
+          oscSubscribed: null,
+        },
+        x32: {
+          enabled: false,
+          connected: false,
+          channels: [],
+        },
         elapsedColor: "",
         remainingColor: "",
         clockColor: "",
@@ -699,6 +733,14 @@ function App() {
   useEffect(() => {
     if (selectedLayout) setDraftRoot(selectedLayout.root);
   }, [selectedLayout]);
+
+  // Announce the active layout (on startup, switches, and renames) so the
+  // main process can feed Companion button feedbacks.
+  useEffect(() => {
+    if (selectedLayout?.name) {
+      window.api.send("layout:active", selectedLayout.name);
+    }
+  }, [selectedLayout?.name]);
 
   useEffect(() => {
     layoutsRef.current = layouts;
@@ -852,6 +894,12 @@ function App() {
     if (widgetKey === "recorderStatus" || widgetKey === "recorderMedia") {
       const first = state.recorders[0];
       return { recorderId: first?.id };
+    }
+    if (widgetKey === "x32Channel" || widgetKey === "x32Meter") {
+      return { x32Channel: 1 };
+    }
+    if (widgetKey === "displayTile") {
+      return { displayKey: `value${generateId().slice(0, 4)}` };
     }
     return undefined;
   };
@@ -1023,6 +1071,42 @@ function App() {
       </Option>
     </Dropdown>
   );
+
+  const x32ChannelLabel = (channelNumber: number) => {
+    const channel = state.x32.channels[channelNumber - 1];
+    const padded = channelNumber.toString().padStart(2, "0");
+    return channel?.name ? `${padded} ${channel.name}` : `Ch ${padded}`;
+  };
+
+  const renderX32ChannelPicker = (node: WidgetNode) => {
+    const selected = node.settings?.x32Channel ?? 1;
+    return (
+      <Dropdown
+        size="small"
+        value={x32ChannelLabel(selected)}
+        selectedOptions={[String(selected)]}
+        onOptionSelect={(_e, data) => {
+          if (data.optionValue === "__manage__") {
+            window.api.send("preferences:open", "mixer");
+            return;
+          }
+          const parsed = parseInt(data.optionValue || "", 10);
+          if (!isNaN(parsed)) {
+            handleUpdateWidgetSettings(node.id, { x32Channel: parsed });
+          }
+        }}
+      >
+        {Array.from({ length: 32 }, (_, i) => i + 1).map((i) => (
+          <Option key={i} value={String(i)} text={x32ChannelLabel(i)}>
+            {x32ChannelLabel(i)}
+          </Option>
+        ))}
+        <Option value="__manage__" text="Configure mixer…">
+          Configure mixer…
+        </Option>
+      </Dropdown>
+    );
+  };
 
   const renderWidgetBody = (node: WidgetNode, isEditing: boolean) => {
     const widget = widgetCatalog[node.widgetKey];
@@ -1313,6 +1397,70 @@ function App() {
             fontSize: "min(10cqw, 28cqh)",
           }}
           faceTitle={fps ? `${display} (${fps} fps)` : display}
+        />
+      );
+    }
+
+    if (node.widgetKey === "ccgHealth") {
+      const cg = state.casparcg;
+      const offline = cg.enabled && !cg.connected;
+      const display = !cg.enabled
+        ? "—"
+        : offline
+        ? "OFFLINE"
+        : cg.latencyMs != null
+        ? `${cg.latencyMs} ms`
+        : "OK";
+      const healthColor = !cg.enabled ? "#888" : offline ? "#dc2626" : "#22c55e";
+      const healthTitle = !cg.enabled
+        ? "Set the CasparCG server address in Preferences to enable"
+        : offline
+        ? `Disconnected${cg.lastError ? `: ${cg.lastError}` : ""}`
+        : [
+            cg.version ? `CasparCG ${cg.version}` : "Connected",
+            cg.oscSubscribed === false
+              ? "OSC auto-subscribe refused (needs server 2.4+); configure OSC in casparcg.config"
+              : cg.oscSubscribed
+              ? "OSC subscribed"
+              : undefined,
+          ]
+            .filter(Boolean)
+            .join(". ");
+      return (
+        <MonitorWidget
+          label={cg.version ? `CasparCG ${cg.version.split(" ")[0]}` : "CasparCG"}
+          customLabel={customLabel}
+          showLabel={showLabel}
+          display={display}
+          defaultFaceColor={healthColor}
+          colors={colors}
+          ending={offline}
+          faceStyle={{
+            fontFamily: "inherit",
+            fontWeight: 700,
+            letterSpacing: "0.05em",
+            fontSize: "min(11cqw, 30cqh)",
+          }}
+          faceAriaLabel={healthTitle}
+          faceTitle={healthTitle}
+          overlay={
+            cg.connected && cg.oscSubscribed === false ? (
+              <span
+                style={{
+                  position: "absolute",
+                  top: "3cqh",
+                  right: "3cqw",
+                  fontFamily: "system-ui, sans-serif",
+                  color: "#f59e0b",
+                  fontSize: "min(5cqw, 14cqh)",
+                  lineHeight: 1,
+                  pointerEvents: "none",
+                }}
+              >
+                NO OSC PUSH
+              </span>
+            ) : undefined
+          }
         />
       );
     }
@@ -1628,6 +1776,159 @@ function App() {
                 }}
               >
                 {offline} OFFLINE
+              </span>
+            ) : undefined
+          }
+        />
+      );
+    }
+
+    if (node.widgetKey === "displayTile") {
+      const key = node.settings?.displayKey || "value";
+      const value = state.displayValues[key] ?? "";
+      return (
+        <MonitorWidget
+          label={key}
+          customLabel={customLabel}
+          showLabel={showLabel}
+          display={value || "—"}
+          defaultFaceColor={value ? state.clockColor : "#888"}
+          colors={colors}
+          faceStyle={{
+            fontFamily: "inherit",
+            fontSize: "min(10cqw, 24cqh)",
+            padding: "0 4cqw",
+            overflowWrap: "anywhere",
+          }}
+          faceTitle={`Send /display/${key} <value> to update; no arguments clears it`}
+          control={
+            isEditing ? (
+              <Input
+                size="small"
+                value={key}
+                placeholder="key"
+                onChange={(_e, data) =>
+                  handleUpdateWidgetSettings(node.id, {
+                    displayKey: data.value || undefined,
+                  })
+                }
+              />
+            ) : undefined
+          }
+        />
+      );
+    }
+
+    if (node.widgetKey === "x32Channel") {
+      const chNum = node.settings?.x32Channel ?? 1;
+      const channel = state.x32.channels[chNum - 1];
+      const live = state.x32.enabled && state.x32.connected && !!channel;
+      const display = !state.x32.enabled
+        ? "—"
+        : !live
+        ? "OFFLINE"
+        : channel.on
+        ? "ON"
+        : "MUTED";
+      const chColor = !state.x32.enabled
+        ? "#888"
+        : !live
+        ? "#dc2626"
+        : channel.on
+        ? "#22c55e"
+        : "#dc2626";
+      const chTitle = !state.x32.enabled
+        ? "Set the mixer address in Preferences to enable"
+        : !live
+        ? "No reply from the console"
+        : `${x32ChannelLabel(chNum)}: ${channel.on ? "on" : "muted"}, fader ${Math.round(
+            channel.fader * 100
+          )}%`;
+      return (
+        <MonitorWidget
+          label={x32ChannelLabel(chNum)}
+          customLabel={customLabel}
+          showLabel={showLabel}
+          display={display}
+          defaultFaceColor={chColor}
+          colors={colors}
+          ending={state.x32.enabled && !live}
+          faceStyle={{
+            fontFamily: "inherit",
+            fontWeight: 700,
+            letterSpacing: "0.05em",
+            fontSize: "min(12cqw, 35cqh)",
+          }}
+          faceAriaLabel={chTitle}
+          faceTitle={chTitle}
+          control={isEditing ? renderX32ChannelPicker(node) : undefined}
+        />
+      );
+    }
+
+    if (node.widgetKey === "x32Meter") {
+      const chNum = node.settings?.x32Channel ?? 1;
+      const channel = state.x32.channels[chNum - 1];
+      const live = state.x32.enabled && state.x32.connected && !!channel;
+      // Meter floats are linear [0..1]; show them on a dB scale with a
+      // -60 dB floor so quiet-but-present audio still registers.
+      const meter = live ? channel.meter : 0;
+      const db = meter > 0 ? 20 * Math.log10(meter) : -60;
+      const pct = Math.min(100, Math.max(0, ((db + 60) / 60) * 100));
+      const fill = pct > 90 ? "#dc2626" : pct > 75 ? "#f59e0b" : "#22c55e";
+      const meterTitle = !state.x32.enabled
+        ? "Set the mixer address in Preferences to enable"
+        : !live
+        ? "No reply from the console"
+        : `${x32ChannelLabel(chNum)}: ${db <= -60 ? "-inf" : db.toFixed(1)} dB`;
+      return (
+        <MonitorWidget
+          label={x32ChannelLabel(chNum)}
+          customLabel={customLabel}
+          showLabel={showLabel}
+          display={
+            <div
+              style={{
+                width: "22cqw",
+                height: "72cqh",
+                backgroundColor: "#333",
+                borderRadius: "6px",
+                overflow: "hidden",
+                display: "flex",
+                alignItems: "flex-end",
+              }}
+            >
+              <div
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  backgroundColor: fill,
+                  transform: `scaleY(${pct / 100})`,
+                  transformOrigin: "bottom",
+                  transition: "transform 0.15s linear",
+                }}
+              />
+            </div>
+          }
+          colors={colors}
+          faceAriaLabel={meterTitle}
+          faceTitle={meterTitle}
+          control={isEditing ? renderX32ChannelPicker(node) : undefined}
+          overlay={
+            live && !channel.on ? (
+              <span
+                style={{
+                  position: "absolute",
+                  top: "3cqh",
+                  right: "3cqw",
+                  fontFamily: "system-ui, sans-serif",
+                  color: "#dc2626",
+                  fontSize: "min(5cqw, 14cqh)",
+                  lineHeight: 1,
+                  pointerEvents: "none",
+                }}
+              >
+                MUTED
               </span>
             ) : undefined
           }

--- a/src/app/lib/layout-types.ts
+++ b/src/app/lib/layout-types.ts
@@ -12,6 +12,7 @@ export type WidgetKind =
   | "ccgNextClip"
   | "ccgProgress"
   | "ccgFormat"
+  | "ccgHealth"
   | "oscTimer"
   | "ontimeTimer"
   | "ontimeTitle"
@@ -20,7 +21,10 @@ export type WidgetKind =
   | "ontimeExpectedFinish"
   | "recorderStatus"
   | "recorderMedia"
-  | "recorderAggregate";
+  | "recorderAggregate"
+  | "x32Channel"
+  | "x32Meter"
+  | "displayTile";
 
 export type WidgetSettings = {
   timezoneId?: string;
@@ -32,9 +36,18 @@ export type WidgetSettings = {
   oscTimerName?: string;
   targetTime?: string; // HH:MM:SS for timeOfDayCountdown
   recorderId?: string; // hyperdeck id for recorderStatus / recorderMedia
+  x32Channel?: number; // 1-based console channel for x32Channel / x32Meter
+  displayKey?: string; // key watched by displayTile (/display/{key})
 };
 
-export type WidgetGroup = "clocks" | "playback" | "timers" | "ontime" | "recorders";
+export type WidgetGroup =
+  | "clocks"
+  | "playback"
+  | "timers"
+  | "ontime"
+  | "recorders"
+  | "audio"
+  | "utility";
 
 export type WidgetDefinition = {
   key: WidgetKind;

--- a/src/app/lib/widget-catalog.tsx
+++ b/src/app/lib/widget-catalog.tsx
@@ -1,13 +1,16 @@
 import {
   ArrowRepeatAllRegular,
+  BracesVariableRegular,
   CalendarClockRegular,
   ClockRegular,
   DataBarHorizontalRegular,
   FilmstripRegular,
   FlagRegular,
   GlobeRegular,
+  DataBarVerticalRegular,
   HistoryRegular,
   HourglassRegular,
+  MicRegular,
   NextRegular,
   PauseCircleRegular,
   PlayCircleRegular,
@@ -15,6 +18,7 @@ import {
   PulseRegular,
   RecordRegular,
   RectangleLandscapeRegular,
+  ServerRegular,
   StackRegular,
   StorageRegular,
   TextFontRegular,
@@ -31,6 +35,8 @@ export const WIDGET_GROUPS: { id: WidgetGroup; label: string }[] = [
   { id: "timers", label: "Timers" },
   { id: "ontime", label: "Ontime" },
   { id: "recorders", label: "Recorders" },
+  { id: "audio", label: "Audio" },
+  { id: "utility", label: "Utility" },
 ];
 
 export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
@@ -114,6 +120,14 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     color: "#64748b",
     group: "playback",
   },
+  ccgHealth: {
+    key: "ccgHealth",
+    label: "Server Health",
+    description: "CasparCG AMCP connection, version and round-trip latency",
+    icon: <ServerRegular />,
+    color: "#22c55e",
+    group: "playback",
+  },
   timeOfDayCountdown: {
     key: "timeOfDayCountdown",
     label: "Time-of-day Countdown",
@@ -193,5 +207,30 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <StackRegular />,
     color: "#dc2626",
     group: "recorders",
+  },
+  x32Channel: {
+    key: "x32Channel",
+    label: "X32 Channel",
+    description: "Mute state and name of an X32/M32 input channel",
+    icon: <MicRegular />,
+    color: "#f43f5e",
+    group: "audio",
+  },
+  x32Meter: {
+    key: "x32Meter",
+    label: "X32 Meter",
+    description: "Live input level meter for an X32/M32 channel",
+    icon: <DataBarVerticalRegular />,
+    color: "#10b981",
+    group: "audio",
+  },
+  displayTile: {
+    key: "displayTile",
+    label: "Variable Tile",
+    description:
+      "Shows any value pushed to /display/{key} over OSC (e.g. a Bitfocus Companion variable)",
+    icon: <BracesVariableRegular />,
+    color: "#eab308",
+    group: "utility",
   },
 };

--- a/src/app/preferences/CompanionSettings.tsx
+++ b/src/app/preferences/CompanionSettings.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import {
+  Field,
+  Input,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+
+const useStyles = makeStyles({
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalL,
+    padding: tokens.spacingVerticalXL,
+  },
+  field: {
+    maxWidth: "400px",
+  },
+});
+
+interface CompanionSettingsProps {
+  host: string;
+  port: number;
+  variable: string;
+  onHostChange: (value: string) => void;
+  onPortChange: (value: number) => void;
+  onVariableChange: (value: string) => void;
+}
+
+export const CompanionSettings: React.FC<CompanionSettingsProps> = ({
+  host,
+  port,
+  variable,
+  onHostChange,
+  onPortChange,
+  onVariableChange,
+}) => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.section}>
+      <Field
+        label="Companion address"
+        hint="Bitfocus Companion host. CGTimer announces the active layout there so button feedbacks can light the current one. Leave empty to disable."
+        className={styles.field}
+      >
+        <Input
+          type="text"
+          value={host}
+          placeholder="e.g. 192.168.1.20"
+          onChange={(_, data) => onHostChange(data.value.trim())}
+        />
+      </Field>
+
+      <Field
+        label="OSC port"
+        hint="Companion's inbound OSC port (default 12321)"
+        className={styles.field}
+      >
+        <Input
+          type="number"
+          value={port.toString()}
+          onChange={(_, data) => {
+            const value = parseInt(data.value, 10);
+            if (!isNaN(value) && value >= 1 && value <= 65535) {
+              onPortChange(value);
+            }
+          }}
+        />
+      </Field>
+
+      <Field
+        label="Custom variable"
+        hint="Companion custom variable set to the active layout name. Create it in Companion under Variables, then compare it in a button's Check-variable-value feedback."
+        className={styles.field}
+      >
+        <Input
+          type="text"
+          value={variable}
+          placeholder="cgtimer_layout"
+          onChange={(_, data) => onVariableChange(data.value.trim())}
+        />
+      </Field>
+    </div>
+  );
+};

--- a/src/app/preferences/MixerSettings.tsx
+++ b/src/app/preferences/MixerSettings.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {
+  Field,
+  Input,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+
+const useStyles = makeStyles({
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalL,
+    padding: tokens.spacingVerticalXL,
+  },
+  field: {
+    maxWidth: "400px",
+  },
+});
+
+interface MixerSettingsProps {
+  x32Host: string;
+  x32Port: number;
+  onX32HostChange: (value: string) => void;
+  onX32PortChange: (value: number) => void;
+}
+
+export const MixerSettings: React.FC<MixerSettingsProps> = ({
+  x32Host,
+  x32Port,
+  onX32HostChange,
+  onX32PortChange,
+}) => {
+  const styles = useStyles();
+
+  return (
+    <div className={styles.section}>
+      <Field
+        label="X32 / M32 address"
+        hint="Console address for the X32 Channel and X32 Meter widgets. Leave empty to disable."
+        className={styles.field}
+      >
+        <Input
+          type="text"
+          value={x32Host}
+          placeholder="e.g. 192.168.1.50"
+          onChange={(_, data) => onX32HostChange(data.value.trim())}
+        />
+      </Field>
+
+      <Field
+        label="OSC port"
+        hint="X32/M32 remote port (default 10023; X-Air consoles use 10024)"
+        className={styles.field}
+      >
+        <Input
+          type="number"
+          value={x32Port.toString()}
+          onChange={(_, data) => {
+            const value = parseInt(data.value, 10);
+            if (!isNaN(value) && value >= 1 && value <= 65535) {
+              onX32PortChange(value);
+            }
+          }}
+        />
+      </Field>
+    </div>
+  );
+};

--- a/src/app/preferences/PreferencesWindow.tsx
+++ b/src/app/preferences/PreferencesWindow.tsx
@@ -14,8 +14,12 @@ import {
   AppGenericRegular,
   ClockRegular,
   ColorRegular,
+  GridRegular,
+  MusicNote2Regular,
   RecordRegular,
 } from "@fluentui/react-icons";
+import { CompanionSettings } from "./CompanionSettings";
+import { MixerSettings } from "./MixerSettings";
 import { ServerSettings } from "./ServerSettings";
 import { ApplicationSettings } from "./ApplicationSettings";
 import { ColorSettings } from "./ColorSettings";
@@ -73,7 +77,9 @@ type TabValue =
   | "application"
   | "colors"
   | "timezones"
-  | "recorders";
+  | "recorders"
+  | "mixer"
+  | "companion";
 
 const TAB_VALUES: TabValue[] = [
   "server",
@@ -81,6 +87,8 @@ const TAB_VALUES: TabValue[] = [
   "colors",
   "timezones",
   "recorders",
+  "mixer",
+  "companion",
 ];
 
 const isTabValue = (value: string): value is TabValue =>
@@ -115,7 +123,15 @@ export const PreferencesWindow: React.FC = () => {
       console.log("Loaded settings:", loadedSettings);
       // Ensure settings have all required sections with defaults
       setSettings({
-        server: loadedSettings?.server || { port: 6251, channel: 1 },
+        // Spread over defaults so configs saved before a key existed still
+        // produce a fully-populated object.
+        server: {
+          host: "",
+          amcpPort: 5250,
+          port: 6251,
+          channel: 1,
+          ...loadedSettings?.server,
+        },
         application:
           loadedSettings?.application ||
           { display: 0, displayLabel: "", displayX: 0, displayY: 0, fullscreen: false },
@@ -124,15 +140,24 @@ export const PreferencesWindow: React.FC = () => {
           { clock: "#960000", elapsed: "#00FF00", remaining: "#FF0000" },
         timezones: loadedSettings?.timezones || { clocks: [] },
         recorders: loadedSettings?.recorders || { hyperdecks: [] },
+        mixer: { x32Host: "", x32Port: 10023, ...loadedSettings?.mixer },
+        companion: {
+          host: "",
+          port: 12321,
+          variable: "cgtimer_layout",
+          ...loadedSettings?.companion,
+        },
       });
     }).catch((error) => {
       console.error("Error loading settings:", error);
       setSettings({
-        server: { port: 6251, channel: 1 },
+        server: { host: "", amcpPort: 5250, port: 6251, channel: 1 },
         application: { display: 0, displayLabel: "", displayX: 0, displayY: 0, fullscreen: false },
         colors: { clock: "#960000", elapsed: "#00FF00", remaining: "#FF0000" },
         timezones: { clocks: [] },
         recorders: { hyperdecks: [] },
+        mixer: { x32Host: "", x32Port: 10023 },
+        companion: { host: "", port: 12321, variable: "cgtimer_layout" },
       });
     });
   }, []);
@@ -212,14 +237,26 @@ export const PreferencesWindow: React.FC = () => {
               <Tab value="recorders" icon={<RecordRegular />}>
                 Recorders
               </Tab>
+              <Tab value="mixer" icon={<MusicNote2Regular />}>
+                Mixer
+              </Tab>
+              <Tab value="companion" icon={<GridRegular />}>
+                Companion
+              </Tab>
             </TabList>
           </div>
 
           <div className={styles.main}>
             {selectedTab === "server" && (
               <ServerSettings
+                host={settings.server.host}
+                amcpPort={settings.server.amcpPort}
                 port={settings.server.port}
                 channel={settings.server.channel}
+                onHostChange={(value) => updateSetting("server", "host", value)}
+                onAmcpPortChange={(value) =>
+                  updateSetting("server", "amcpPort", value)
+                }
                 onPortChange={(value) => updateSetting("server", "port", value)}
                 onChannelChange={(value) =>
                   updateSetting("server", "channel", value)
@@ -270,6 +307,36 @@ export const PreferencesWindow: React.FC = () => {
                 hyperdecks={settings.recorders.hyperdecks}
                 onChange={(hyperdecks) =>
                   updateSetting("recorders", "hyperdecks", hyperdecks)
+                }
+              />
+            )}
+
+            {selectedTab === "mixer" && (
+              <MixerSettings
+                x32Host={settings.mixer.x32Host}
+                x32Port={settings.mixer.x32Port}
+                onX32HostChange={(value) =>
+                  updateSetting("mixer", "x32Host", value)
+                }
+                onX32PortChange={(value) =>
+                  updateSetting("mixer", "x32Port", value)
+                }
+              />
+            )}
+
+            {selectedTab === "companion" && (
+              <CompanionSettings
+                host={settings.companion.host}
+                port={settings.companion.port}
+                variable={settings.companion.variable}
+                onHostChange={(value) =>
+                  updateSetting("companion", "host", value)
+                }
+                onPortChange={(value) =>
+                  updateSetting("companion", "port", value)
+                }
+                onVariableChange={(value) =>
+                  updateSetting("companion", "variable", value)
                 }
               />
             )}

--- a/src/app/preferences/ServerSettings.tsx
+++ b/src/app/preferences/ServerSettings.tsx
@@ -19,15 +19,23 @@ const useStyles = makeStyles({
 });
 
 interface ServerSettingsProps {
+  host: string;
+  amcpPort: number;
   port: number;
   channel: number;
+  onHostChange: (value: string) => void;
+  onAmcpPortChange: (value: number) => void;
   onPortChange: (value: number) => void;
   onChannelChange: (value: number) => void;
 }
 
 export const ServerSettings: React.FC<ServerSettingsProps> = ({
+  host,
+  amcpPort,
   port,
   channel,
+  onHostChange,
+  onAmcpPortChange,
   onPortChange,
   onChannelChange,
 }) => {
@@ -35,6 +43,36 @@ export const ServerSettings: React.FC<ServerSettingsProps> = ({
 
   return (
     <div className={styles.section}>
+      <Field
+        label="Server address"
+        hint="CasparCG host for AMCP: powers the Server Health widget and asks the server (2.4+) to stream OSC here automatically. Leave empty to disable."
+        className={styles.field}
+      >
+        <Input
+          type="text"
+          value={host}
+          placeholder="e.g. 127.0.0.1"
+          onChange={(_, data) => onHostChange(data.value.trim())}
+        />
+      </Field>
+
+      <Field
+        label="AMCP port"
+        hint="CasparCG AMCP TCP port (default 5250)"
+        className={styles.field}
+      >
+        <Input
+          type="number"
+          value={amcpPort.toString()}
+          onChange={(_, data) => {
+            const value = parseInt(data.value, 10);
+            if (!isNaN(value) && value >= 1 && value <= 65535) {
+              onAmcpPortChange(value);
+            }
+          }}
+        />
+      </Field>
+
       <Field
         label="Port"
         hint="CasparCG OSC Port"

--- a/src/casparcg.ts
+++ b/src/casparcg.ts
@@ -1,0 +1,226 @@
+import * as net from "node:net";
+import { EventEmitter } from "node:events";
+
+/**
+ * Minimal AMCP client for CasparCG Server (TCP/5250), used for health
+ * monitoring and OSC bootstrap rather than playout control.
+ *
+ * Protocol notes (AMCP spec + server source):
+ *  - Replies are `\r\n`-terminated lines: `202 {CMD} OK` carries no data,
+ *    `201 {CMD} OK` is followed by exactly one data line, `200 {CMD} OK` by
+ *    multiple data lines ending with an empty line, and `400 ERROR` echoes
+ *    the offending command on the next line.
+ *  - `PING [token...]` answers with a codeless `PONG [token...]` line; we
+ *    send the wall-clock as the token to measure round-trip latency.
+ *  - `OSC SUBSCRIBE {port}` (2.4+) streams OSC to this client's address for
+ *    the lifetime of the TCP connection, so the server needs no
+ *    casparcg.config changes. Pre-2.4 servers reject it with `400 ERROR`.
+ */
+
+export type AmcpSnapshot = {
+  enabled: boolean;
+  connected: boolean;
+  lastError: string | null;
+  version: string;
+  latencyMs: number | null;
+  /** null = not answered yet, false = server refused (pre-2.4). */
+  oscSubscribed: boolean | null;
+};
+
+export const DISABLED_AMCP_SNAPSHOT: AmcpSnapshot = {
+  enabled: false,
+  connected: false,
+  lastError: null,
+  version: "",
+  latencyMs: null,
+  oscSubscribed: null,
+};
+
+const RECONNECT_DELAY_MS = 5000;
+const PING_INTERVAL_MS = 3000;
+
+export class AmcpClient extends EventEmitter {
+  readonly host: string;
+  readonly port: number;
+  /** UDP port CGTimer listens on; passed to OSC SUBSCRIBE. */
+  readonly oscPort: number;
+  private socket: net.Socket | null = null;
+  private buffer = "";
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private disposed = false;
+  /** Which command's data line(s) the next reply line belongs to. */
+  private pendingDataFor: "version" | "error-echo" | null = null;
+
+  connected = false;
+  lastError: string | null = null;
+  version = "";
+  latencyMs: number | null = null;
+  oscSubscribed: boolean | null = null;
+
+  constructor(opts: { host: string; port: number; oscPort: number }) {
+    super();
+    this.host = opts.host;
+    this.port = opts.port;
+    this.oscPort = opts.oscPort;
+  }
+
+  start() {
+    if (this.disposed) return;
+    if (this.socket) return;
+
+    const socket = new net.Socket();
+    this.socket = socket;
+    this.buffer = "";
+    this.pendingDataFor = null;
+
+    socket.setEncoding("utf8");
+
+    console.log(`[amcp] connecting to ${this.host}:${this.port}`);
+
+    socket.on("connect", () => {
+      this.connected = true;
+      this.lastError = null;
+      this.emit("change");
+      console.log(`[amcp] connected`);
+      socket.write("VERSION\r\n");
+      socket.write(`OSC SUBSCRIBE ${this.oscPort}\r\n`);
+      this.sendPing();
+      this.pingTimer = setInterval(() => this.sendPing(), PING_INTERVAL_MS);
+    });
+
+    socket.on("data", (data: string) => this.ingest(data));
+
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      this.lastError = err.code || err.message || String(err);
+      console.warn(`[amcp] socket error: ${this.lastError}`);
+      // The matching "close" will fire next; let it handle the cleanup.
+    });
+
+    socket.on("close", () => {
+      const wasConnected = this.connected;
+      this.connected = false;
+      if (this.pingTimer) {
+        clearInterval(this.pingTimer);
+        this.pingTimer = null;
+      }
+      this.version = "";
+      this.latencyMs = null;
+      this.oscSubscribed = null;
+      this.socket = null;
+      if (wasConnected) {
+        console.log(`[amcp] disconnected`);
+      }
+      this.emit("change");
+      if (!this.disposed) {
+        this.scheduleReconnect();
+      }
+    });
+
+    socket.connect(this.port, this.host);
+  }
+
+  stop() {
+    this.disposed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
+    this.connected = false;
+    this.emit("change");
+  }
+
+  snapshot(): AmcpSnapshot {
+    return {
+      enabled: true,
+      connected: this.connected,
+      lastError: this.lastError,
+      version: this.version,
+      latencyMs: this.latencyMs,
+      oscSubscribed: this.oscSubscribed,
+    };
+  }
+
+  private sendPing() {
+    if (this.socket && this.connected) {
+      this.socket.write(`PING ${Date.now()}\r\n`);
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.start();
+    }, RECONNECT_DELAY_MS);
+  }
+
+  private ingest(chunk: string) {
+    this.buffer += chunk;
+    while (true) {
+      const nl = this.buffer.indexOf("\r\n");
+      if (nl < 0) return;
+      const line = this.buffer.slice(0, nl);
+      this.buffer = this.buffer.slice(nl + 2);
+      this.handleLine(line);
+    }
+  }
+
+  private handleLine(line: string) {
+    if (this.pendingDataFor === "version") {
+      this.pendingDataFor = null;
+      this.version = line.trim();
+      this.emit("change");
+      return;
+    }
+
+    if (this.pendingDataFor === "error-echo") {
+      this.pendingDataFor = null;
+      if (line.toUpperCase().includes("OSC SUBSCRIBE")) {
+        this.oscSubscribed = false;
+        this.emit("change");
+      }
+      return;
+    }
+
+    const pongMatch = /^PONG(?:\s+(\S+))?/i.exec(line);
+    if (pongMatch) {
+      const sentAt = Number(pongMatch[1]);
+      if (Number.isFinite(sentAt)) {
+        this.latencyMs = Math.max(0, Date.now() - sentAt);
+        this.emit("change");
+      }
+      return;
+    }
+
+    const replyMatch = /^(\d{3})\s+(.*)$/.exec(line);
+    if (!replyMatch) return;
+    const code = parseInt(replyMatch[1], 10);
+    const text = replyMatch[2].toUpperCase();
+
+    if (code === 201 && text.startsWith("VERSION")) {
+      this.pendingDataFor = "version";
+      return;
+    }
+
+    if (text.includes("OSC SUBSCRIBE")) {
+      this.oscSubscribed = code < 400;
+      this.emit("change");
+      return;
+    }
+
+    if (code === 400) {
+      // `400 ERROR` echoes the failing command on the next line; that is how
+      // a pre-2.4 server rejects OSC SUBSCRIBE.
+      this.pendingDataFor = "error-echo";
+    }
+  }
+}

--- a/src/companion.ts
+++ b/src/companion.ts
@@ -1,0 +1,89 @@
+import osc, { UDPPort } from "osc";
+
+/**
+ * Announces CGTimer state to a Bitfocus Companion instance over Companion's
+ * inbound OSC API (default port 12321).
+ *
+ * On every layout activation (and on a keepalive interval, so a restarted
+ * Companion converges without user action) this sends:
+ *  - `/custom-variable/{variable}/value "<layout name>"` — Companion's
+ *    documented path for setting a custom variable, which button feedbacks
+ *    can compare against to light the active layout.
+ *  - `/layout/active "<layout name>"` — a generic announcement for any
+ *    non-Companion OSC consumer pointed at the same target.
+ */
+
+const KEEPALIVE_MS = 10000;
+
+export class CompanionAnnouncer {
+  readonly host: string;
+  readonly port: number;
+  readonly variable: string;
+  private udp: UDPPort | null = null;
+  private ready = false;
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+  private activeLayout = "";
+
+  constructor(opts: { host: string; port: number; variable: string }) {
+    this.host = opts.host;
+    this.port = opts.port;
+    this.variable = opts.variable;
+  }
+
+  start() {
+    if (this.udp) return;
+
+    const udp = new osc.UDPPort({
+      localAddress: "0.0.0.0",
+      localPort: 0,
+      remoteAddress: this.host,
+      remotePort: this.port,
+      metadata: true,
+    });
+    this.udp = udp;
+
+    udp.on("ready", () => {
+      this.ready = true;
+      this.announce();
+      this.keepaliveTimer = setInterval(() => this.announce(), KEEPALIVE_MS);
+    });
+
+    udp.on("error", (error: Error) => {
+      // UDP send errors are transient; the keepalive retries anyway.
+      console.warn(`[companion] error: ${error.message}`);
+    });
+
+    udp.open();
+  }
+
+  stop() {
+    if (this.keepaliveTimer) {
+      clearInterval(this.keepaliveTimer);
+      this.keepaliveTimer = null;
+    }
+    if (this.udp) {
+      this.udp.close();
+      this.udp = null;
+    }
+    this.ready = false;
+  }
+
+  setActiveLayout(name: string) {
+    this.activeLayout = name;
+    this.announce();
+  }
+
+  private announce() {
+    if (!this.ready || !this.udp || !this.activeLayout) return;
+    const value = [{ type: "s", value: this.activeLayout }];
+    try {
+      this.udp.send({
+        address: `/custom-variable/${this.variable}/value`,
+        args: value,
+      });
+      this.udp.send({ address: "/layout/active", args: value });
+    } catch (error) {
+      console.warn(`[companion] send failed: ${String(error)}`);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,9 @@ import oscListener from "./osc";
 import store from "./store";
 import type { StoreSchema } from "./store";
 import { HyperDeckClient, HyperDeckSnapshot } from "./hyperdeck";
+import { AmcpClient, DISABLED_AMCP_SNAPSHOT } from "./casparcg";
+import { X32Client, DISABLED_X32_SNAPSHOT } from "./x32";
+import { CompanionAnnouncer } from "./companion";
 
 
 // In development, electron-vite sets ELECTRON_RENDERER_URL environment variable
@@ -17,6 +20,95 @@ let mainWindow: BrowserWindow | null = null;
 let timer: NodeJS.Timeout;
 let layoutShortcuts: string[] = [];
 const hyperdeckClients = new Map<string, HyperDeckClient>();
+let amcpClient: AmcpClient | null = null;
+
+const reconcileAmcp = () => {
+  const server = store.get("server");
+  const desired = server.host
+    ? {
+        host: server.host,
+        port: server.amcpPort || 5250,
+        oscPort: server.port,
+      }
+    : null;
+
+  if (
+    amcpClient &&
+    (!desired ||
+      amcpClient.host !== desired.host ||
+      amcpClient.port !== desired.port ||
+      amcpClient.oscPort !== desired.oscPort)
+  ) {
+    amcpClient.stop();
+    amcpClient = null;
+  }
+
+  if (desired && !amcpClient) {
+    amcpClient = new AmcpClient(desired);
+    amcpClient.start();
+  }
+};
+
+let x32Client: X32Client | null = null;
+
+const reconcileX32 = () => {
+  const mixer = store.get("mixer") || { x32Host: "", x32Port: 10023 };
+  const desired = mixer.x32Host
+    ? { host: mixer.x32Host, port: mixer.x32Port || 10023 }
+    : null;
+
+  if (
+    x32Client &&
+    (!desired ||
+      x32Client.host !== desired.host ||
+      x32Client.port !== desired.port)
+  ) {
+    x32Client.stop();
+    x32Client = null;
+  }
+
+  if (desired && !x32Client) {
+    x32Client = new X32Client(desired);
+    x32Client.start();
+  }
+};
+
+let companionAnnouncer: CompanionAnnouncer | null = null;
+// Remembered across reconciles so a freshly-configured target hears the
+// current layout immediately instead of waiting for the next switch.
+let activeLayoutName = "";
+
+const reconcileCompanion = () => {
+  const companion = store.get("companion") || {
+    host: "",
+    port: 12321,
+    variable: "cgtimer_layout",
+  };
+  const desired = companion.host
+    ? {
+        host: companion.host,
+        port: companion.port || 12321,
+        variable: companion.variable || "cgtimer_layout",
+      }
+    : null;
+
+  if (
+    companionAnnouncer &&
+    (!desired ||
+      companionAnnouncer.host !== desired.host ||
+      companionAnnouncer.port !== desired.port ||
+      companionAnnouncer.variable !== desired.variable)
+  ) {
+    companionAnnouncer.stop();
+    companionAnnouncer = null;
+  }
+
+  if (desired && !companionAnnouncer) {
+    companionAnnouncer = new CompanionAnnouncer(desired);
+    companionAnnouncer.setActiveLayout(activeLayoutName);
+    companionAnnouncer.start();
+  }
+};
 
 const reconcileHyperDecks = () => {
   const desired = (store.get("recorders").hyperdecks || []).filter(
@@ -277,6 +369,9 @@ const createWindow = (): void => {
   Menu.setApplicationMenu(buildMenu());
 
   reconcileHyperDecks();
+  reconcileAmcp();
+  reconcileX32();
+  reconcileCompanion();
 
   timer = setInterval(() => {
     mainWindow?.webContents.send("timers:update", {
@@ -298,11 +393,14 @@ const createWindow = (): void => {
       ccgBackgroundCued: osc.isBackgroundCued(),
       ccgFormat: osc.channelFormat,
       ccgFramerate: osc.channelFramerate,
+      displayValues: osc.getDisplayValues(),
       elapsedColor: store.get("colors.elapsed"),
       remainingColor: store.get("colors.remaining"),
       clockColor: store.get("colors.clock"),
       timezoneClocks: store.get("timezones.clocks") || [],
       recorders: collectHyperDeckSnapshots(),
+      casparcg: amcpClient ? amcpClient.snapshot() : DISABLED_AMCP_SNAPSHOT,
+      x32: x32Client ? x32Client.snapshot() : DISABLED_X32_SNAPSHOT,
     });
   }, 200);
 };
@@ -315,6 +413,8 @@ ipcMain.handle("settings:get", (): StoreSchema => {
     colors: store.get("colors"),
     timezones: store.get("timezones"),
     recorders: store.get("recorders"),
+    mixer: store.get("mixer"),
+    companion: store.get("companion"),
   };
 });
 
@@ -324,8 +424,13 @@ ipcMain.handle("settings:save", (_, settings: StoreSchema) => {
   store.set("colors", settings.colors);
   store.set("timezones", settings.timezones);
   store.set("recorders", settings.recorders);
+  store.set("mixer", settings.mixer);
+  store.set("companion", settings.companion);
 
   reconcileHyperDecks();
+  reconcileAmcp();
+  reconcileX32();
+  reconcileCompanion();
 
   // Refresh the display signature so a freshly-picked monitor can be
   // re-matched after a disconnect even if its id changes.
@@ -351,6 +456,8 @@ ipcMain.handle("settings:reset", (): StoreSchema => {
     colors: store.get("colors"),
     timezones: store.get("timezones"),
     recorders: store.get("recorders"),
+    mixer: store.get("mixer"),
+    companion: store.get("companion"),
   };
 });
 
@@ -364,6 +471,11 @@ ipcMain.on("preferences:open", (_event, tab?: string) => {
 
 ipcMain.on("menubar:set-visible", (_event, visible: boolean) => {
   mainWindow?.setMenuBarVisibility(!!visible);
+});
+
+ipcMain.on("layout:active", (_event, name: string) => {
+  activeLayoutName = String(name || "");
+  companionAnnouncer?.setActiveLayout(activeLayoutName);
 });
 
 ipcMain.on("layouts:update", (_event, layoutNames: string[]) => {

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -24,6 +24,7 @@ class oscListener {
   channelFramerate: number;
   foregroundSeenAt: number;
   backgroundSeenAt: number;
+  displayValues: Map<string, string>;
   udpPort: UDPPort | undefined;
   onLayoutLoad?: (layoutName: string) => void;
   onTimerCommand?: (name: string, action: TimerAction, value?: number) => void;
@@ -51,6 +52,7 @@ class oscListener {
     this.channelFramerate = 0;
     this.foregroundSeenAt = 0;
     this.backgroundSeenAt = 0;
+    this.displayValues = new Map();
     this.udpPort = undefined;
     this.onLayoutLoad = onLayoutLoad;
     this.onTimerCommand = onTimerCommand;
@@ -82,6 +84,12 @@ class oscListener {
       // Handle timer commands: /timer/{name}/{action}
       if (message["address"].startsWith("/timer/")) {
         this.parseTimerCommand(message);
+        return;
+      }
+
+      // Handle display tiles: /display/{key} <value...>
+      if (message["address"].startsWith("/display/")) {
+        this.parseDisplayMessage(message);
         return;
       }
 
@@ -233,6 +241,37 @@ class oscListener {
     }
   };
 
+  /** Cap so a stray OSC source spamming random keys cannot grow memory forever. */
+  private static readonly MAX_DISPLAY_KEYS = 512;
+
+  private parseDisplayMessage = (message: OSCMessage) => {
+    const key = message["address"].slice("/display/".length);
+    if (!key) return;
+
+    const args = message["args"] || [];
+    // No arguments (or a single empty string) clears the tile.
+    const value = args
+      .map((arg) => String(arg?.value ?? ""))
+      .join(" ")
+      .trim();
+
+    if (!value) {
+      this.displayValues.delete(key);
+      return;
+    }
+    if (
+      !this.displayValues.has(key) &&
+      this.displayValues.size >= oscListener.MAX_DISPLAY_KEYS
+    ) {
+      return;
+    }
+    this.displayValues.set(key, value);
+  };
+
+  public getDisplayValues = (): Record<string, string> => {
+    return Object.fromEntries(this.displayValues);
+  };
+
   private parseTimerCommand = (message: OSCMessage) => {
     if (!this.onTimerCommand) return;
 
@@ -284,6 +323,7 @@ class oscListener {
     this.channelFramerate = 0;
     this.foregroundSeenAt = 0;
     this.backgroundSeenAt = 0;
+    this.displayValues.clear();
   };
 
   /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,9 @@ import { HyperDeck, TimezoneClock } from "./shared/entities";
 
 export interface StoreSchema {
   server: {
+    /** CasparCG address for AMCP; empty string disables the client. */
+    host: string;
+    amcpPort: number;
     port: number;
     channel: number;
   };
@@ -27,12 +30,34 @@ export interface StoreSchema {
   recorders: {
     hyperdecks: HyperDeck[];
   };
+  mixer: {
+    /** X32/M32 console address; empty string disables the client. */
+    x32Host: string;
+    x32Port: number;
+  };
+  companion: {
+    /** Bitfocus Companion address; empty string disables announcements. */
+    host: string;
+    port: number;
+    /** Companion custom variable set to the active layout name. */
+    variable: string;
+  };
 }
 
 const schema: Schema<StoreSchema> = {
   server: {
     type: "object",
     properties: {
+      host: {
+        type: "string",
+        default: "",
+      },
+      amcpPort: {
+        type: "number",
+        default: 5250,
+        minimum: 1,
+        maximum: 65535,
+      },
       port: {
         type: "number",
         default: 6251,
@@ -130,11 +155,47 @@ const schema: Schema<StoreSchema> = {
       },
     },
   },
+  mixer: {
+    type: "object",
+    properties: {
+      x32Host: {
+        type: "string",
+        default: "",
+      },
+      x32Port: {
+        type: "number",
+        default: 10023,
+        minimum: 1,
+        maximum: 65535,
+      },
+    },
+  },
+  companion: {
+    type: "object",
+    properties: {
+      host: {
+        type: "string",
+        default: "",
+      },
+      port: {
+        type: "number",
+        default: 12321,
+        minimum: 1,
+        maximum: 65535,
+      },
+      variable: {
+        type: "string",
+        default: "cgtimer_layout",
+      },
+    },
+  },
 };
 
 // Default values for the store
 const defaults: StoreSchema = {
   server: {
+    host: "",
+    amcpPort: 5250,
     port: 6251,
     channel: 1,
   },
@@ -155,6 +216,15 @@ const defaults: StoreSchema = {
   },
   recorders: {
     hyperdecks: [],
+  },
+  mixer: {
+    x32Host: "",
+    x32Port: 10023,
+  },
+  companion: {
+    host: "",
+    port: 12321,
+    variable: "cgtimer_layout",
   },
 };
 

--- a/src/types/osc.d.ts
+++ b/src/types/osc.d.ts
@@ -1,5 +1,5 @@
 declare module "osc" {
-  export type OSCValue = string | number | boolean | null;
+  export type OSCValue = string | number | boolean | null | Uint8Array;
 
   export interface OSCMessage {
     address: string;
@@ -9,6 +9,8 @@ declare module "osc" {
   export interface UDPPortOptions {
     localAddress: string;
     localPort: number;
+    remoteAddress?: string;
+    remotePort?: number;
     metadata?: boolean;
   }
 
@@ -18,6 +20,10 @@ declare module "osc" {
       event: "message",
       listener: (oscMessage: OSCMessage, timetag?: unknown, info?: unknown) => void
     ): void;
+    on(event: "ready", listener: () => void): void;
+    on(event: "error", listener: (error: Error) => void): void;
+    /** Sends to the configured remoteAddress/remotePort. */
+    send(message: OSCMessage): void;
     open(): void;
     close(): void;
   }

--- a/src/x32.ts
+++ b/src/x32.ts
@@ -1,0 +1,195 @@
+import osc, { OSCMessage, UDPPort } from "osc";
+import { EventEmitter } from "node:events";
+
+/**
+ * Client for the Behringer X32/M32 OSC remote protocol (UDP/10023).
+ *
+ * Protocol notes (Patrick-Gilles Maillot's unofficial protocol doc):
+ *  - Sending a parameter address with no arguments queries it; the console
+ *    echoes the address back with the current value.
+ *  - `/xremote` (no args) subscribes this client to all parameter changes
+ *    for 10 seconds and must be renewed to stay live.
+ *  - `/meters ,s /meters/1` streams the METERS/channel page as OSC blobs
+ *    (~50 ms cadence) for 10 seconds: 96 floats where indexes 0-31 are the
+ *    32 input channel levels. Inside the blob: an int32 little-endian float
+ *    count followed by little-endian float32 values.
+ *  - `/ch/NN/mix/on` is {OFF, ON} as int 0/1 (1 = unmuted), `mix/fader` is a
+ *    level float [0..1], `config/name` a string.
+ *  - UDP is connectionless, so liveness is inferred from replies: anything
+ *    received within the last few seconds counts as connected.
+ */
+
+export type X32ChannelState = {
+  /** 1-based console channel number. */
+  index: number;
+  name: string;
+  /** true = channel ON (unmuted). */
+  on: boolean;
+  /** Fader level [0..1]. */
+  fader: number;
+  /** Input meter level [0..1], linear. */
+  meter: number;
+};
+
+export type X32Snapshot = {
+  enabled: boolean;
+  connected: boolean;
+  channels: X32ChannelState[];
+};
+
+export const DISABLED_X32_SNAPSHOT: X32Snapshot = {
+  enabled: false,
+  connected: false,
+  channels: [],
+};
+
+export const X32_CHANNEL_COUNT = 32;
+const SUBSCRIPTION_RENEW_MS = 8000; // /xremote and /meters expire after 10 s
+const OFFLINE_AFTER_MS = 5000;
+
+const pad2 = (n: number) => n.toString().padStart(2, "0");
+
+export class X32Client extends EventEmitter {
+  readonly host: string;
+  readonly port: number;
+  private udp: UDPPort | null = null;
+  private renewTimer: ReturnType<typeof setInterval> | null = null;
+  private disposed = false;
+  private lastReplyAt = 0;
+
+  channels: X32ChannelState[] = Array.from(
+    { length: X32_CHANNEL_COUNT },
+    (_, i) => ({ index: i + 1, name: "", on: true, fader: 0, meter: 0 })
+  );
+
+  constructor(opts: { host: string; port: number }) {
+    super();
+    this.host = opts.host;
+    this.port = opts.port;
+  }
+
+  start() {
+    if (this.disposed) return;
+    if (this.udp) return;
+
+    const udp = new osc.UDPPort({
+      localAddress: "0.0.0.0",
+      localPort: 0, // ephemeral; the console replies to our source port
+      remoteAddress: this.host,
+      remotePort: this.port,
+      metadata: true,
+    });
+    this.udp = udp;
+
+    console.log(`[x32] talking to ${this.host}:${this.port}`);
+
+    udp.on("ready", () => {
+      this.subscribe();
+      this.queryChannelState();
+      this.renewTimer = setInterval(() => this.subscribe(), SUBSCRIPTION_RENEW_MS);
+    });
+
+    udp.on("message", (message: OSCMessage) => this.handleMessage(message));
+
+    udp.on("error", (error: Error) => {
+      // UDP errors are transient (e.g. EHOSTUNREACH); staleness handles state.
+      console.warn(`[x32] error: ${error.message}`);
+    });
+
+    udp.open();
+  }
+
+  stop() {
+    this.disposed = true;
+    if (this.renewTimer) {
+      clearInterval(this.renewTimer);
+      this.renewTimer = null;
+    }
+    if (this.udp) {
+      this.udp.close();
+      this.udp = null;
+    }
+    this.emit("change");
+  }
+
+  get connected(): boolean {
+    return Date.now() - this.lastReplyAt < OFFLINE_AFTER_MS;
+  }
+
+  snapshot(): X32Snapshot {
+    return {
+      enabled: true,
+      connected: this.connected,
+      channels: this.channels.map((c) => ({ ...c })),
+    };
+  }
+
+  private send(address: string, args: OSCMessage["args"] = []) {
+    if (!this.udp) return;
+    try {
+      this.udp.send({ address, args });
+    } catch (error) {
+      console.warn(`[x32] send failed: ${String(error)}`);
+    }
+  }
+
+  private subscribe() {
+    this.send("/xremote");
+    this.send("/meters", [{ type: "s", value: "/meters/1" }]);
+  }
+
+  /** Argument-less sends are queries; the console echoes current values. */
+  private queryChannelState() {
+    for (let i = 1; i <= X32_CHANNEL_COUNT; i++) {
+      this.send(`/ch/${pad2(i)}/config/name`);
+      this.send(`/ch/${pad2(i)}/mix/on`);
+      this.send(`/ch/${pad2(i)}/mix/fader`);
+    }
+  }
+
+  private handleMessage(message: OSCMessage) {
+    this.lastReplyAt = Date.now();
+
+    if (message.address === "/meters/1") {
+      const blob = message.args?.[0]?.value;
+      if (blob instanceof Uint8Array) {
+        this.applyMeters(blob);
+      }
+      return;
+    }
+
+    const chMatch = /^\/ch\/(\d{2})\/(config\/name|mix\/on|mix\/fader)$/.exec(
+      message.address
+    );
+    if (!chMatch) return;
+    const idx = parseInt(chMatch[1], 10) - 1;
+    if (idx < 0 || idx >= X32_CHANNEL_COUNT) return;
+    const raw = message.args?.[0]?.value;
+    const channel = this.channels[idx];
+
+    switch (chMatch[2]) {
+      case "config/name":
+        channel.name = String(raw ?? "");
+        break;
+      case "mix/on":
+        channel.on = Number(raw) === 1;
+        break;
+      case "mix/fader":
+        channel.fader = Number(raw) || 0;
+        break;
+    }
+    this.emit("change");
+  }
+
+  private applyMeters(blob: Uint8Array) {
+    // Inside the OSC blob: int32 LE float count, then LE float32 values.
+    if (blob.byteLength < 4) return;
+    const view = new DataView(blob.buffer, blob.byteOffset, blob.byteLength);
+    const count = view.getInt32(0, true);
+    const available = Math.floor((blob.byteLength - 4) / 4);
+    const usable = Math.min(count, available, X32_CHANNEL_COUNT);
+    for (let i = 0; i < usable; i++) {
+      this.channels[i].meter = view.getFloat32(4 + i * 4, true);
+    }
+  }
+}


### PR DESCRIPTION
Four integrations that extend CGTimer beyond passive OSC listening.

## CasparCG AMCP client

- New `src/casparcg.ts` TCP client (port 5250, HyperDeck-style lifecycle) powering a **Server Health** widget: reachability, server version, and `PING` round-trip latency, red-blinking `OFFLINE` on disconnect.
- Issues `OSC SUBSCRIBE <port>` on every connect, so CasparCG 2.4+ streams OSC to CGTimer with zero `casparcg.config` changes. Pre-2.4 servers reject it (`400 ERROR` + command echo); the widget then shows a `NO OSC PUSH` badge so the manual config path is discoverable.
- Server address and AMCP port fields added to the Server preferences tab (empty address = disabled).
- Protocol semantics verified against the CasparCG server source (2.3.3-lts through master).

## X32/M32 audio widgets

- New `src/x32.ts` client for the console OSC remote protocol (UDP/10023): `/xremote` + `/meters ,s /meters/1` subscriptions renewed inside the 10 s timeout, argument-less queries for initial channel names/mutes/faders, and little-endian meter blob decoding per Maillot's protocol doc.
- **X32 Channel**: green `ON` / red `MUTED` lamp, labeled with the live console channel name.
- **X32 Meter**: vertical dB-scale VU bar (-60 dB floor, green/amber/red zones) with a `MUTED` corner badge when the metered channel is off.
- Both share an edit-mode channel picker showing live console names. New Mixer preferences tab (default port 10023, X-Air hint).

## Variable Tile

- New `/display/{key} <value>` address on CGTimer's existing OSC server; a **Variable Tile** widget (new Utility group) renders the pushed value. No arguments clears the tile; multi-arg messages join with spaces; key count capped at 512 against stray senders.
- Primary use case: a Bitfocus Companion generic-OSC trigger pushing any Companion variable, making CGTimer a readout wall for every device Companion knows.

## Companion layout feedback

- New `src/companion.ts` announcer: pushes the active layout name to Companion's inbound OSC API (`/custom-variable/{name}/value`, default port 12321) on startup, every layout switch or rename, and a 10 s keepalive, plus a generic `/layout/active` for other consumers.
- Closes the Stream Deck loop: buttons send `/layout/load`, and a Check-variable-value feedback lights the button for whichever layout is actually live, from any switching source (OSC, menu shortcuts, dock).
- New Companion preferences tab (host, port, variable name).

## Notes

- The preferences window now merges loaded settings over per-key defaults, so configs saved before these sections existed still populate the UI safely.
- `tsc`, `eslint`, and `electron-vite build` pass. Each client was smoke-tested against a scripted fake peer: AMCP (2.4+ accept, 2.3-style reject, unreachable host), X32 (query sync, async `/xremote` push, meter blob decode), the OSC listener (tile set/clear/multi-arg plus a channel-filter regression check), and the Companion announcer (announce-on-ready and on-switch).