### PR TITLE
Per-widget help dialog with live data source readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ and `/meters` and renews automatically; channel names, mute states and
 fader levels come straight from the desk, so relabeling a channel on the
 console updates the dashboard.
 
+### Widget setup guidance
+
+In edit mode, every widget card has a `?` button next to the split and
+color actions. It opens a help dialog with what the widget shows, how to
+read its states, the live status of its data source (never configured,
+configured but silent, offline, or pointing at a deleted
+timezone/recorder, with a "last packet" line for OSC sources), and
+numbered setup steps with an Open settings button that jumps to the
+right Preferences tab. When the source needs attention, the `?` icon is
+tinted amber (setup needed) or red (offline / broken reference). Run
+mode is unaffected.
+
 ### Layout editor
 
 In edit mode (toggle from the dock), drag widgets from the palette onto an

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -52,6 +52,7 @@ import {
   PauseRegular,
   PlayRegular,
   ProhibitedRegular,
+  QuestionCircleRegular,
   RecordRegular,
   ReOrderRegular,
   RenameRegular,
@@ -66,6 +67,15 @@ import { PromptDialog } from "./components/PromptDialog";
 import { Draggable, DragData } from "./components/Draggable";
 import { Droppable } from "./components/Droppable";
 import { ColorConfigPanel, getWidgetColors } from "./components/ColorConfigPanel";
+import { WidgetHelpDialog } from "./components/WidgetHelpDialog";
+import {
+  ReadinessState,
+  formatLastData,
+  getWidgetReadiness,
+  integrationHelp,
+  interpolate,
+  sourceTelemetry,
+} from "./lib/widget-readiness";
 import {
   Edge,
   LayoutNode,
@@ -407,6 +417,13 @@ function App() {
     ccgFormat: "",
     ccgFramerate: 0,
     displayValues: {} as Record<string, string>,
+    sources: {
+      ccgOsc: { lastSeenAt: 0, lastSender: "" },
+      ontime: { lastSeenAt: 0, lastSender: "" },
+      oscTimer: { lastSeenAt: 0, lastSender: "" },
+      display: { lastSeenAt: 0, lastSender: "" },
+      oscPort: 0,
+    },
     casparcg: {
       enabled: false,
       connected: false,
@@ -473,6 +490,7 @@ function App() {
   );
   const layoutsRef = useRef<SavedLayout[]>(initialLayouts);
   const [configuringWidgetId, setConfiguringWidgetId] = useState<string | null>(null);
+  const [helpWidgetId, setHelpWidgetId] = useState<string | null>(null);
   const [mode, setMode] = useState<"edit" | "preview">("preview");
   const [showEditor, setShowEditor] = useState(false);
   const [dockState, setDockState] = useState(() => {
@@ -631,6 +649,13 @@ function App() {
         ccgFormat: "",
         ccgFramerate: 0,
         displayValues: {},
+        sources: {
+          ccgOsc: { lastSeenAt: 0, lastSender: "" },
+          ontime: { lastSeenAt: 0, lastSender: "" },
+          oscTimer: { lastSeenAt: 0, lastSender: "" },
+          display: { lastSeenAt: 0, lastSender: "" },
+          oscPort: 0,
+        },
         casparcg: {
           enabled: false,
           connected: false,
@@ -755,7 +780,10 @@ function App() {
   }, [layouts]);
 
   useEffect(() => {
-    if (mode !== "edit" || !showEditor) setConfiguringWidgetId(null);
+    if (mode !== "edit" || !showEditor) {
+      setConfiguringWidgetId(null);
+      setHelpWidgetId(null);
+    }
   }, [mode, showEditor]);
 
   useEffect(() => {
@@ -926,6 +954,7 @@ function App() {
 
   const handleRemoveWidget = (id: string) => {
     if (configuringWidgetId === id) setConfiguringWidgetId(null);
+    if (helpWidgetId === id) setHelpWidgetId(null);
     setDraftRoot((prev) => removeNode(prev, id));
   };
 
@@ -1108,6 +1137,89 @@ function App() {
     );
   };
 
+  const renderTimezonePicker = (node: WidgetNode) => {
+    const timezones = state.timezoneClocks;
+    const selectedTimezone = timezones.find(
+      (tz) => tz.id === node.settings?.timezoneId
+    );
+    return (
+      <Dropdown
+        size="small"
+        value={selectedTimezone?.label ?? "Local time"}
+        selectedOptions={[selectedTimezone?.id ?? ""]}
+        onOptionSelect={(_e, data) => {
+          if (data.optionValue === "__manage__") {
+            window.api.send("preferences:open", "timezones");
+            return;
+          }
+          handleUpdateWidgetSettings(node.id, {
+            timezoneId: data.optionValue || undefined,
+          });
+        }}
+      >
+        <Option value="">Local time</Option>
+        {timezones.map((tz) => (
+          <Option key={tz.id} value={tz.id} text={tz.label}>
+            {tz.label}
+          </Option>
+        ))}
+        <Option value="__manage__" text="Manage timezones…">
+          Manage timezones…
+        </Option>
+      </Dropdown>
+    );
+  };
+
+  const renderTargetTimeInput = (node: WidgetNode) => (
+    <Input
+      size="small"
+      value={node.settings?.targetTime || "20:00:00"}
+      placeholder="HH:MM:SS"
+      onChange={(_e, data) =>
+        handleUpdateWidgetSettings(node.id, {
+          targetTime: data.value || undefined,
+        })
+      }
+    />
+  );
+
+  const renderOscTimerNameInput = (node: WidgetNode) => (
+    <Input
+      size="small"
+      value={node.settings?.oscTimerName || "default"}
+      placeholder="default"
+      onChange={(_e, data) =>
+        handleUpdateWidgetSettings(node.id, {
+          oscTimerName: data.value || undefined,
+        })
+      }
+    />
+  );
+
+  const renderDisplayKeyInput = (node: WidgetNode) => (
+    <Input
+      size="small"
+      value={node.settings?.displayKey || "value"}
+      placeholder="key"
+      onChange={(_e, data) =>
+        handleUpdateWidgetSettings(node.id, {
+          displayKey: data.value || undefined,
+        })
+      }
+    />
+  );
+
+  const readinessState: ReadinessState = {
+    now,
+    sources: state.sources,
+    casparcg: state.casparcg,
+    x32: state.x32,
+    recorders: state.recorders,
+    timezoneClocks: state.timezoneClocks,
+    displayValues: state.displayValues,
+    oscTimerNames: Object.keys(oscTimers),
+  };
+
   const renderWidgetBody = (node: WidgetNode, isEditing: boolean) => {
     const widget = widgetCatalog[node.widgetKey];
     const colors = getWidgetColors(node.settings);
@@ -1115,15 +1227,27 @@ function App() {
     const customLabel = node.settings?.customLabel;
     if (!widget) return <div>Unknown widget</div>;
 
+
     if (node.widgetKey === "worldClock") {
       const timezones = state.timezoneClocks;
-      const fallbackZone = "UTC";
-      const selectedTimezone =
-        timezones.find((tz) => tz.id === node.settings?.timezoneId) || timezones[0];
-      const activeZone = selectedTimezone?.timezone ?? fallbackZone;
-      const activeLabel = selectedTimezone?.label ?? fallbackZone;
-      const defaultLabel = `${activeLabel} (${getTimezoneOffset(activeZone)})`;
-      const time = getTimezoneTime(activeZone, now);
+      // No timezoneId is the explicit "Local time" choice; a set id that no
+      // longer exists is a broken reference (previously it silently showed
+      // the first configured zone).
+      const wantsLocal = !node.settings?.timezoneId;
+      const selectedTimezone = wantsLocal
+        ? undefined
+        : timezones.find((tz) => tz.id === node.settings?.timezoneId);
+      const broken = !wantsLocal && !selectedTimezone;
+      const defaultLabel = wantsLocal
+        ? "Local time"
+        : selectedTimezone
+        ? `${selectedTimezone.label} (${getTimezoneOffset(selectedTimezone.timezone)})`
+        : "Timezone missing";
+      const time = wantsLocal
+        ? clockTime(now)
+        : selectedTimezone
+        ? getTimezoneTime(selectedTimezone.timezone, now)
+        : "--:--:--";
 
       return (
         <MonitorWidget
@@ -1131,36 +1255,10 @@ function App() {
           customLabel={customLabel}
           showLabel={showLabel}
           display={time}
-          defaultFaceColor={state.clockColor}
+          defaultFaceColor={broken ? "#888" : state.clockColor}
           colors={colors}
-          control={
-            isEditing ? (
-              <Dropdown
-                size="small"
-                value={selectedTimezone?.label ?? "Local time"}
-                selectedOptions={[selectedTimezone?.id ?? ""]}
-                onOptionSelect={(_e, data) => {
-                  if (data.optionValue === "__manage__") {
-                    window.api.send("preferences:open", "timezones");
-                    return;
-                  }
-                  handleUpdateWidgetSettings(node.id, {
-                    timezoneId: data.optionValue || undefined,
-                  });
-                }}
-              >
-                <Option value="">Local time</Option>
-                {timezones.map((tz) => (
-                  <Option key={tz.id} value={tz.id} text={tz.label}>
-                    {tz.label}
-                  </Option>
-                ))}
-                <Option value="__manage__" text="Manage timezones…">
-                  Manage timezones…
-                </Option>
-              </Dropdown>
-            ) : undefined
-          }
+          faceTitle={broken ? "Timezone no longer configured" : undefined}
+          control={isEditing ? renderTimezonePicker(node) : undefined}
         />
       );
     }
@@ -1208,20 +1306,7 @@ function App() {
           display={display}
           defaultFaceColor={overdue ? "red" : state.clockColor}
           colors={colors}
-          control={
-            isEditing ? (
-              <Input
-                size="small"
-                value={target}
-                placeholder="HH:MM:SS"
-                onChange={(_e, data) =>
-                  handleUpdateWidgetSettings(node.id, {
-                    targetTime: data.value || undefined,
-                  })
-                }
-              />
-            ) : undefined
-          }
+          control={isEditing ? renderTargetTimeInput(node) : undefined}
         />
       );
     }
@@ -1507,20 +1592,7 @@ function App() {
           display={displayTime}
           defaultFaceColor={state.clockColor}
           colors={colors}
-          control={
-            isEditing ? (
-              <Input
-                size="small"
-                value={timerName}
-                placeholder="default"
-                onChange={(_e, data) =>
-                  handleUpdateWidgetSettings(node.id, {
-                    oscTimerName: data.value || undefined,
-                  })
-                }
-              />
-            ) : undefined
-          }
+          control={isEditing ? renderOscTimerNameInput(node) : undefined}
         />
       );
     }
@@ -1642,9 +1714,11 @@ function App() {
 
     if (node.widgetKey === "recorderStatus") {
       const recorders = state.recorders;
-      const recorder =
-        recorders.find((r) => r.id === node.settings?.recorderId) ||
-        recorders[0];
+      // Fall back to the first deck only when nothing is configured; a set id
+      // that no longer matches must not silently show a different machine.
+      const recorder = node.settings?.recorderId
+        ? recorders.find((r) => r.id === node.settings?.recorderId)
+        : recorders[0];
       const recording = recorder?.status === "record";
       // HyperDeck reports timecode as HH:MM:SS:FF or HH:MM:SS;FF (drop-frame).
       // Strip the frame portion so the widget shows the same HH:MM:SS as our other timers.
@@ -1693,9 +1767,11 @@ function App() {
 
     if (node.widgetKey === "recorderMedia") {
       const recorders = state.recorders;
-      const recorder =
-        recorders.find((r) => r.id === node.settings?.recorderId) ||
-        recorders[0];
+      // Fall back to the first deck only when nothing is configured; a set id
+      // that no longer matches must not silently show a different machine.
+      const recorder = node.settings?.recorderId
+        ? recorders.find((r) => r.id === node.settings?.recorderId)
+        : recorders[0];
       const remaining = recorder?.recordingTimeRemaining;
       const hasMedia =
         !!recorder?.connected &&
@@ -1801,20 +1877,7 @@ function App() {
             overflowWrap: "anywhere",
           }}
           faceTitle={`Send /display/${key} <value> to update; no arguments clears it`}
-          control={
-            isEditing ? (
-              <Input
-                size="small"
-                value={key}
-                placeholder="key"
-                onChange={(_e, data) =>
-                  handleUpdateWidgetSettings(node.id, {
-                    displayKey: data.value || undefined,
-                  })
-                }
-              />
-            ) : undefined
-          }
+          control={isEditing ? renderDisplayKeyInput(node) : undefined}
         />
       );
     }
@@ -1942,6 +2005,17 @@ function App() {
   const renderWidget = (node: WidgetNode) => {
     const widget = widgetCatalog[node.widgetKey];
     const widgetLabel = widget?.label ?? "Widget";
+    const helpReadiness = widget
+      ? getWidgetReadiness(node.widgetKey, widget.source, node.settings, readinessState)
+      : null;
+    // Tint the help icon so "needs attention" stays visible at a glance even
+    // though the explanation now lives behind the modal.
+    const helpTint =
+      helpReadiness && helpReadiness.level !== "ready"
+        ? helpReadiness.level === "offline" || helpReadiness.level === "brokenRef"
+          ? "#dc2626"
+          : "#f59e0b"
+        : undefined;
 
     const titleBlock = (
       <div>
@@ -2002,6 +2076,19 @@ function App() {
             </MenuList>
           </MenuPopover>
         </Menu>
+        <Tooltip content="What is this widget?" relationship="label" withArrow>
+          <Button
+            appearance="subtle"
+            size="small"
+            icon={
+              <QuestionCircleRegular
+                style={helpTint ? { color: helpTint } : undefined}
+              />
+            }
+            aria-label="Widget help"
+            onClick={() => setHelpWidgetId(node.id)}
+          />
+        </Tooltip>
         <Popover
           open={configuringWidgetId === node.id}
           onOpenChange={(_e, data) =>
@@ -2347,6 +2434,40 @@ function App() {
           ) : null}
         </DragOverlay>
       </DndContext>
+
+      {(() => {
+        if (!helpWidgetId) return null;
+        const helpNode = findWidget(draftRoot, helpWidgetId);
+        const def = helpNode ? widgetCatalog[helpNode.widgetKey] : undefined;
+        if (!helpNode || !def) return null;
+        const readiness = getWidgetReadiness(
+          helpNode.widgetKey,
+          def.source,
+          helpNode.settings,
+          readinessState
+        );
+        const telemetry = sourceTelemetry(def.source, readinessState);
+        return (
+          <WidgetHelpDialog
+            open
+            widget={def}
+            readiness={
+              readiness.level === "ready"
+                ? readiness
+                : {
+                    ...readiness,
+                    reason: interpolate(readiness.reason, readinessState),
+                  }
+            }
+            setupSteps={integrationHelp[def.source].setup.map((step) =>
+              interpolate(step, readinessState)
+            )}
+            setupHint={interpolate(def.setupHint, readinessState)}
+            lastData={telemetry ? formatLastData(telemetry, now) : undefined}
+            onClose={() => setHelpWidgetId(null)}
+          />
+        );
+      })()}
 
       <PromptDialog
         open={!!renameTargetId}

--- a/src/app/components/WidgetHelpDialog.tsx
+++ b/src/app/components/WidgetHelpDialog.tsx
@@ -1,0 +1,160 @@
+import {
+  Body1,
+  Button,
+  Caption1,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import { WidgetDefinition } from "../lib/layout-types";
+import { Readiness } from "../lib/widget-readiness";
+
+const LEVEL_COLORS: Record<string, string> = {
+  ready: "#22c55e",
+  unconfigured: "#888",
+  waiting: "#f59e0b",
+  offline: "#dc2626",
+  brokenRef: "#f59e0b",
+};
+
+const LEVEL_LABELS: Record<string, string> = {
+  ready: "Receiving data",
+  unconfigured: "Not configured",
+  waiting: "Configured, waiting for data",
+  offline: "Offline",
+  brokenRef: "Broken reference",
+};
+
+const useStyles = makeStyles({
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: tokens.spacingVerticalXS,
+    marginBottom: tokens.spacingVerticalM,
+  },
+  heading: {
+    color: tokens.colorNeutralForeground3,
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+  },
+  status: {
+    display: "flex",
+    alignItems: "baseline",
+    columnGap: tokens.spacingHorizontalS,
+  },
+  statusDot: {
+    fontSize: "10px",
+    lineHeight: 1,
+  },
+  steps: {
+    margin: 0,
+    paddingLeft: tokens.spacingHorizontalXXL,
+    display: "flex",
+    flexDirection: "column",
+    rowGap: tokens.spacingVerticalXS,
+  },
+});
+
+export type WidgetHelpDialogProps = {
+  open: boolean;
+  widget: WidgetDefinition;
+  readiness: Readiness;
+  /** Shared integration steps, already {oscPort}-interpolated. */
+  setupSteps: string[];
+  /** Widget-specific hint, already interpolated. */
+  setupHint: string;
+  /** "Last packet: ..." line for OSC-fed sources. */
+  lastData?: string;
+  onClose: () => void;
+};
+
+/**
+ * Edit-mode help modal opened from the (?) button on a widget card: what the
+ * widget shows, how to read it, live source status, and setup steps with a
+ * deep link to the right preferences tab.
+ */
+export function WidgetHelpDialog({
+  open,
+  widget,
+  readiness,
+  setupSteps,
+  setupHint,
+  lastData,
+  onClose,
+}: WidgetHelpDialogProps) {
+  const styles = useStyles();
+  const statusColor = LEVEL_COLORS[readiness.level];
+  const statusReason = "reason" in readiness ? readiness.reason : undefined;
+  const prefsTab = "prefsTab" in readiness ? readiness.prefsTab : widget.prefsTab;
+
+  return (
+    <Dialog open={open} onOpenChange={(_e, data) => !data.open && onClose()}>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>{widget.label}</DialogTitle>
+          <DialogContent>
+            <div className={styles.section}>
+              <Body1>{widget.description}</Body1>
+            </div>
+
+            <div className={styles.section}>
+              <Caption1 className={styles.heading}>How to read it</Caption1>
+              <Body1>{widget.reading}</Body1>
+            </div>
+
+            <div className={styles.section}>
+              <Caption1 className={styles.heading}>Current status</Caption1>
+              <div className={styles.status}>
+                <span className={styles.statusDot} style={{ color: statusColor }}>
+                  ●
+                </span>
+                <Body1>
+                  {LEVEL_LABELS[readiness.level]}
+                  {statusReason ? `: ${statusReason}` : ""}
+                </Body1>
+              </div>
+              {lastData && <Caption1>{lastData}</Caption1>}
+            </div>
+
+            {(setupSteps.length > 0 || setupHint) && (
+              <div className={styles.section}>
+                <Caption1 className={styles.heading}>Setup</Caption1>
+                {setupSteps.length > 0 && (
+                  <ol className={styles.steps}>
+                    {setupSteps.map((step, i) => (
+                      <li key={i}>
+                        <Body1>{step}</Body1>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+                {setupHint && <Body1>{setupHint}</Body1>}
+              </div>
+            )}
+          </DialogContent>
+          <DialogActions>
+            {widget.source !== "none" && prefsTab && (
+              <Button
+                appearance="primary"
+                onClick={() => {
+                  window.api.send("preferences:open", prefsTab);
+                  onClose();
+                }}
+              >
+                Open settings
+              </Button>
+            )}
+            <Button appearance="secondary" onClick={onClose}>
+              Close
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/src/app/lib/layout-types.ts
+++ b/src/app/lib/layout-types.ts
@@ -49,6 +49,26 @@ export type WidgetGroup =
   | "audio"
   | "utility";
 
+/** The data source a widget depends on, for readiness detection and help. */
+export type SourceId =
+  | "none" // local clock only
+  | "timezones" // worldClock
+  | "ccgOsc" // CasparCG OSC feed widgets
+  | "ccgAmcp" // ccgHealth
+  | "ontime" // Ontime OSC widgets
+  | "oscTimer" // OSC-driven stopwatches
+  | "display" // /display/{key} tiles
+  | "hyperdeck" // recorder widgets
+  | "x32"; // X32/M32 widgets
+
+/** Deep-link targets accepted by the preferences:open IPC. */
+export type PrefsTab =
+  | "server"
+  | "recorders"
+  | "mixer"
+  | "timezones"
+  | "companion";
+
 export type WidgetDefinition = {
   key: WidgetKind;
   label: string;
@@ -56,6 +76,19 @@ export type WidgetDefinition = {
   icon: ReactElement;
   color: string;
   group: WidgetGroup;
+  /** Which data source feeds this widget; drives the readiness UI. */
+  source: SourceId;
+  /** 1-2 sentences of setup guidance; "{oscPort}" is interpolated at render time. */
+  setupHint: string;
+  /** 1-2 sentences decoding the face states; appended to the hover title. */
+  reading: string;
+  /** Preferences tab the guided face deep-links to; omit only for source "none". */
+  prefsTab?: PrefsTab;
+  /**
+   * The widget renders its own honest offline/empty state, so the readiness
+   * layer should not add a second indicator on top of it in run mode.
+   */
+  hasBuiltInStatus?: boolean;
 };
 
 export type WidgetNode = {

--- a/src/app/lib/widget-catalog.tsx
+++ b/src/app/lib/widget-catalog.tsx
@@ -4,10 +4,10 @@ import {
   CalendarClockRegular,
   ClockRegular,
   DataBarHorizontalRegular,
+  DataBarVerticalRegular,
   FilmstripRegular,
   FlagRegular,
   GlobeRegular,
-  DataBarVerticalRegular,
   HistoryRegular,
   HourglassRegular,
   MicRegular,
@@ -39,6 +39,9 @@ export const WIDGET_GROUPS: { id: WidgetGroup; label: string }[] = [
   { id: "utility", label: "Utility" },
 ];
 
+// setupHint and reading follow the copy rules in docs/widget-help-design.md:
+// max 2 sentences each, plain text, no URLs, "{oscPort}" interpolated at
+// render time, and every hint names the preferences tab it refers to.
 export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
   worldClock: {
     key: "worldClock",
@@ -47,6 +50,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <GlobeRegular />,
     color: "#3b82f6",
     group: "clocks",
+    source: "timezones",
+    prefsTab: "timezones",
+    setupHint:
+      "Add timezones in Preferences > Timezones, then pick one from the dropdown on the widget.",
+    reading:
+      "Always live; a frozen 00:00:00 means the saved timezone is invalid. The header offset is whole hours relative to this machine.",
   },
   localClock: {
     key: "localClock",
@@ -55,6 +64,10 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <ClockRegular />,
     color: "#14b8a6",
     group: "clocks",
+    source: "none",
+    setupHint: "Works out of the box; follows the OS clock and timezone.",
+    reading:
+      "Shows the OS clock. An unsynced system clock shows the wrong time with no indication.",
   },
   primaryTimer: {
     key: "primaryTimer",
@@ -63,6 +76,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <HourglassRegular />,
     color: "#f59e0b",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}: set the Server address in Preferences > Server (2.4+), or add a predefined OSC client in casparcg.config (2.3).",
+    reading:
+      "Orange from halfway, red in the last quarter. Freezes at the last value if the feed stops; pair with Now Playing to see feed liveness.",
   },
   secondaryTimer: {
     key: "secondaryTimer",
@@ -71,6 +90,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <HistoryRegular />,
     color: "#22c55e",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}: set the Server address in Preferences > Server (2.4+), or add a predefined OSC client in casparcg.config (2.3).",
+    reading:
+      "Freezes at the last value if the feed stops; a stopped clip and a dead feed look identical.",
   },
   loopState: {
     key: "loopState",
@@ -79,6 +104,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <ArrowRepeatAllRegular />,
     color: "#a855f7",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}; configure it in Preferences > Server.",
+    reading:
+      "The grey crossed icon means loop off or no data from CasparCG; the two look identical.",
   },
   ccgClipName: {
     key: "ccgClipName",
@@ -87,6 +118,13 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <FilmstripRegular />,
     color: "#06b6d4",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    hasBuiltInStatus: true,
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}; configure it in Preferences > Server.",
+    reading:
+      "The grey dash appears within 1.5 s of the feed going silent or the layer clearing, so this widget doubles as a feed-liveness canary.",
   },
   ccgPaused: {
     key: "ccgPaused",
@@ -95,6 +133,13 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <PauseCircleRegular />,
     color: "#f59e0b",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    hasBuiltInStatus: true,
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}; configure it in Preferences > Server.",
+    reading:
+      "No clip also means no OSC feed for 1.5 s; use Server Health to disambiguate.",
   },
   ccgNextClip: {
     key: "ccgNextClip",
@@ -103,6 +148,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <NextRegular />,
     color: "#8b5cf6",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}, and a playout workflow that cues with LOADBG; PLAY-only workflows always show NOT CUED.",
+    reading:
+      "NOT CUED right after a TAKE is normal. Blinks red when the playing clip has 10 s left with nothing cued behind it.",
   },
   ccgProgress: {
     key: "ccgProgress",
@@ -111,6 +162,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <DataBarHorizontalRegular />,
     color: "#22c55e",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}; configure it in Preferences > Server.",
+    reading:
+      "Fill color follows the Remaining Timer thresholds. The bar freezes at its last position if the feed stops.",
   },
   ccgFormat: {
     key: "ccgFormat",
@@ -119,6 +176,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <RectangleLandscapeRegular />,
     color: "#64748b",
     group: "playback",
+    source: "ccgOsc",
+    prefsTab: "server",
+    setupHint:
+      "Needs the CasparCG OSC feed on port {oscPort}; the video-mode string needs CasparCG 2.4 or newer.",
+    reading:
+      "The value latches: it persists across disconnects and even a server restart until fresh packets arrive.",
   },
   ccgHealth: {
     key: "ccgHealth",
@@ -127,6 +190,13 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <ServerRegular />,
     color: "#22c55e",
     group: "playback",
+    source: "ccgAmcp",
+    prefsTab: "server",
+    hasBuiltInStatus: true,
+    setupHint:
+      "Set the Server address and AMCP port (default 5250) in Preferences > Server; empty address disables the client.",
+    reading:
+      "Monitors the AMCP TCP link only; it can be green while OSC widgets are dashed, and vice versa. NO OSC PUSH means the server predates OSC SUBSCRIBE (2.4) and needs a manual casparcg.config OSC client.",
   },
   timeOfDayCountdown: {
     key: "timeOfDayCountdown",
@@ -135,6 +205,11 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <CalendarClockRegular />,
     color: "#ef4444",
     group: "timers",
+    source: "none",
+    setupHint:
+      "Type the target as zero-padded HH:MM:SS on the widget in edit mode; no external device needed.",
+    reading:
+      "Counts up with a + prefix and turns red after the target passes. The target is always today; it never rolls to tomorrow.",
   },
   oscTimer: {
     key: "oscTimer",
@@ -143,6 +218,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <PulseRegular />,
     color: "#ec4899",
     group: "timers",
+    source: "oscTimer",
+    prefsTab: "server",
+    setupHint:
+      "Send /timer/{name}/start, /stop, /reset, /toggle or /set <ms> to UDP port {oscPort}; the widget's name must match the address exactly (case sensitive).",
+    reading:
+      "00:00:00 means never started, reset, or a name mismatch; a wrong port looks identical to a stopped timer. Running timers persist across app restarts.",
   },
   ontimeTimer: {
     key: "ontimeTimer",
@@ -151,6 +232,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <PlugConnectedRegular />,
     color: "#10b981",
     group: "ontime",
+    source: "ontime",
+    prefsTab: "server",
+    setupHint:
+      "In Ontime, enable OSC output to this machine on port {oscPort} and cycle /from-ontime/current with {{timer.current}} every second.",
+    reading:
+      "Negative overtime shows a minus and turns red. Freezes at the last value if Ontime stops sending.",
   },
   ontimeTitle: {
     key: "ontimeTitle",
@@ -159,6 +246,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <TextFontRegular />,
     color: "#0ea5e9",
     group: "ontime",
+    source: "ontime",
+    prefsTab: "server",
+    setupHint:
+      "In Ontime, enable OSC output to this machine on port {oscPort} and cycle /from-ontime/title with {{eventNow.title}} every second.",
+    reading:
+      "A dash means no title received or no current event; a stale title persists if Ontime stops sending.",
   },
   ontimePlayback: {
     key: "ontimePlayback",
@@ -167,6 +260,13 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <PlayCircleRegular />,
     color: "#84cc16",
     group: "ontime",
+    source: "ontime",
+    prefsTab: "server",
+    hasBuiltInStatus: true,
+    setupHint:
+      "In Ontime, enable OSC output to this machine on port {oscPort} and cycle /from-ontime/playback with {{playback}} every second.",
+    reading:
+      "The crossed circle with a dash label means no data, not stopped; stopped shows a Stop icon.",
   },
   ontimeOnAir: {
     key: "ontimeOnAir",
@@ -175,6 +275,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <RecordRegular />,
     color: "#dc2626",
     group: "ontime",
+    source: "ontime",
+    prefsTab: "server",
+    setupHint:
+      "In Ontime, enable OSC output to this machine on port {oscPort} and cycle /from-ontime/onAir with {{onAir}} every second.",
+    reading:
+      "OFF also means no data at all, and an ON AIR display can outlive a crashed Ontime; there is no staleness check.",
   },
   ontimeExpectedFinish: {
     key: "ontimeExpectedFinish",
@@ -183,6 +289,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <FlagRegular />,
     color: "#f97316",
     group: "ontime",
+    source: "ontime",
+    prefsTab: "server",
+    setupHint:
+      "In Ontime, enable OSC output to this machine on port {oscPort} and cycle /from-ontime/expectedFinish with {{timer.expectedEnd}} every second.",
+    reading:
+      "Dashes mean no running event or no data. Events ending after midnight can show times like 25:10:00.",
   },
   recorderStatus: {
     key: "recorderStatus",
@@ -191,6 +303,13 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <RecordRegular />,
     color: "#dc2626",
     group: "recorders",
+    source: "hyperdeck",
+    prefsTab: "recorders",
+    hasBuiltInStatus: true,
+    setupHint:
+      "Add the deck in Preferences > Recorders (TCP port 9993), then pick it from the dropdown on the widget.",
+    reading:
+      "ST:ND:BY covers every non-record transport state including playback; OF:FL:NE means the TCP connection is down.",
   },
   recorderMedia: {
     key: "recorderMedia",
@@ -199,6 +318,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <StorageRegular />,
     color: "#0ea5e9",
     group: "recorders",
+    source: "hyperdeck",
+    prefsTab: "recorders",
+    setupHint:
+      "Add the deck in Preferences > Recorders (TCP port 9993) and make sure media is mounted in its active slot.",
+    reading:
+      "Shows the ACTIVE slot only; red and blinking under 5 minutes. Hover distinguishes offline, no media, and not-yet-polled.",
   },
   recorderAggregate: {
     key: "recorderAggregate",
@@ -207,6 +332,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <StackRegular />,
     color: "#dc2626",
     group: "recorders",
+    source: "hyperdeck",
+    prefsTab: "recorders",
+    setupHint:
+      "Add decks in Preferences > Recorders; the widget always sums every enabled deck, with no per-widget picker.",
+    reading:
+      "Blinks red only when ALL enabled decks record. Offline decks stay in the total; watch the amber N OFFLINE overlay.",
   },
   x32Channel: {
     key: "x32Channel",
@@ -215,6 +346,13 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <MicRegular />,
     color: "#f43f5e",
     group: "audio",
+    source: "x32",
+    prefsTab: "mixer",
+    hasBuiltInStatus: true,
+    setupHint:
+      "Set the console address in Preferences > Mixer (UDP port 10023), then pick the channel from the dropdown on the widget.",
+    reading:
+      "ON means unmuted on the console, not on-air. OFFLINE appears after 5 s without a console reply.",
   },
   x32Meter: {
     key: "x32Meter",
@@ -223,6 +361,12 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <DataBarVerticalRegular />,
     color: "#10b981",
     group: "audio",
+    source: "x32",
+    prefsTab: "mixer",
+    setupHint:
+      "Set the console address in Preferences > Mixer (UDP port 10023), then pick the channel from the dropdown on the widget.",
+    reading:
+      "Pre-fader input level on a -60 to 0 dB scale, so signal shows even when muted (red MUTED badge). An empty bar can also mean the console is offline; hover to check.",
   },
   displayTile: {
     key: "displayTile",
@@ -232,5 +376,11 @@ export const widgetCatalog: Record<WidgetKind, WidgetDefinition> = {
     icon: <BracesVariableRegular />,
     color: "#eab308",
     group: "utility",
+    source: "display",
+    prefsTab: "server",
+    setupHint:
+      "Send /display/{key} <value> to UDP port {oscPort} and set the widget's key to match (case sensitive; slashes allowed). Sending no arguments clears the tile.",
+    reading:
+      "A grey dash means no value: nothing sent, key mismatch, cleared by the sender, or the app restarted. Values never go stale on their own.",
   },
 };

--- a/src/app/lib/widget-readiness.ts
+++ b/src/app/lib/widget-readiness.ts
@@ -1,0 +1,375 @@
+import { PrefsTab, SourceId, WidgetKind, WidgetSettings } from "./layout-types";
+
+/**
+ * Single home for every "is this widget's data source alive" predicate and
+ * every reason/fix string the guided faces show. Widgets never invent their
+ * own readiness copy, so wording cannot drift per widget.
+ */
+
+export type SourceTelemetry = { lastSeenAt: number; lastSender: string };
+
+/** The slice of the renderer's timers:update state that readiness needs. */
+export type ReadinessState = {
+  /** Wall clock of the render tick, so predicates stay pure. */
+  now: number;
+  sources: {
+    ccgOsc: SourceTelemetry;
+    ontime: SourceTelemetry;
+    oscTimer: SourceTelemetry;
+    display: SourceTelemetry;
+    oscPort: number;
+  };
+  casparcg: {
+    enabled: boolean;
+    connected: boolean;
+    lastError: string | null;
+    latencyMs: number | null;
+    oscSubscribed: boolean | null;
+  };
+  x32: { enabled: boolean; connected: boolean };
+  recorders: Array<{ id: string; connected: boolean; lastError: string | null }>;
+  timezoneClocks: Array<{ id: string }>;
+  displayValues: Record<string, string>;
+  /** Names of OSC timers that have ever received a command. */
+  oscTimerNames: string[];
+};
+
+export type Readiness =
+  | { level: "ready" }
+  | { level: "unconfigured"; reason: string; fixLabel: string; prefsTab: PrefsTab }
+  | { level: "waiting"; reason: string; fixLabel: string; prefsTab: PrefsTab }
+  | { level: "offline"; reason: string; prefsTab: PrefsTab }
+  | { level: "brokenRef"; reason: string; fixLabel: string; prefsTab: PrefsTab };
+
+export type IntegrationHelp = {
+  label: string;
+  prefsTab?: PrefsTab;
+  /** Shared plumbing steps; "{oscPort}" interpolated at render time. */
+  setup: string[];
+};
+
+export const integrationHelp: Record<SourceId, IntegrationHelp> = {
+  none: { label: "Local", setup: [] },
+  timezones: {
+    label: "Timezones",
+    prefsTab: "timezones",
+    setup: [
+      "Preferences > Timezones: add at least one timezone (label, IANA zone, enabled).",
+    ],
+  },
+  ccgOsc: {
+    label: "CasparCG OSC feed",
+    prefsTab: "server",
+    setup: [
+      "Preferences > Server: confirm Port (CGTimer's UDP OSC listen port, default {oscPort}) and Channel.",
+      "CasparCG 2.4+: set Server address in Preferences > Server; CGTimer subscribes to OSC automatically over AMCP.",
+      "CasparCG 2.3 or older: add a predefined OSC client in casparcg.config pointing at this machine's IP, port {oscPort}, then restart the server.",
+    ],
+  },
+  ccgAmcp: {
+    label: "CasparCG AMCP",
+    prefsTab: "server",
+    setup: [
+      "Preferences > Server: set Server address (empty disables the AMCP client) and AMCP port (default 5250).",
+    ],
+  },
+  ontime: {
+    label: "Ontime",
+    prefsTab: "server",
+    setup: [
+      "Ontime > Integrations > OSC: enable OSC output targeting this machine's IP, port {oscPort}.",
+      "Add a cycling integration (every second) sending the widget's /from-ontime/... address with the matching Ontime variable.",
+    ],
+  },
+  oscTimer: {
+    label: "Inbound OSC",
+    prefsTab: "server",
+    setup: [
+      "Point any OSC sender at this machine's IP, UDP port {oscPort} (Preferences > Server > Port). No handshake needed.",
+    ],
+  },
+  display: {
+    label: "Inbound OSC",
+    prefsTab: "server",
+    setup: [
+      "Point any OSC sender at this machine's IP, UDP port {oscPort} (Preferences > Server > Port). No handshake needed.",
+    ],
+  },
+  hyperdeck: {
+    label: "HyperDecks",
+    prefsTab: "recorders",
+    setup: [
+      "Preferences > Recorders: add a deck (label, host, port 9993) and keep it enabled.",
+    ],
+  },
+  x32: {
+    label: "X32 / M32",
+    prefsTab: "mixer",
+    setup: [
+      "Preferences > Mixer: set the console address (empty disables the client) and OSC port (default 10023; X-Air uses 10024).",
+    ],
+  },
+};
+
+/** UDP feeds count as offline after this much silence following real data. */
+const STALE_MS = 3000;
+
+export const interpolate = (text: string, state: ReadinessState): string =>
+  text.replace(/\{oscPort\}/g, String(state.sources.oscPort || 6251));
+
+/** "Last packet: never" / "Last packet: 3 s ago from 192.168.1.10". */
+export const formatLastData = (
+  telemetry: SourceTelemetry,
+  now: number
+): string => {
+  if (!telemetry.lastSeenAt) return "Last packet: never";
+  const seconds = Math.max(0, Math.round((now - telemetry.lastSeenAt) / 1000));
+  const from = telemetry.lastSender ? ` from ${telemetry.lastSender}` : "";
+  return `Last packet: ${seconds} s ago${from}`;
+};
+
+const READY: Readiness = { level: "ready" };
+
+export function getSourceStatus(
+  state: ReadinessState
+): Record<SourceId, Readiness> {
+  const { now, sources, casparcg, x32, recorders, timezoneClocks } = state;
+
+  const udpFamily = (
+    telemetry: SourceTelemetry,
+    unconfiguredReason: string,
+    prefsTab: PrefsTab
+  ): Readiness => {
+    if (!telemetry.lastSeenAt) {
+      return {
+        level: "unconfigured",
+        reason: unconfiguredReason,
+        fixLabel: "Open Server settings",
+        prefsTab,
+      };
+    }
+    if (now - telemetry.lastSeenAt > STALE_MS) {
+      return {
+        level: "offline",
+        reason: `Feed stopped (${formatLastData(telemetry, now).toLowerCase()})`,
+        prefsTab,
+      };
+    }
+    return READY;
+  };
+
+  const ccgOsc: Readiness = (() => {
+    if (!sources.ccgOsc.lastSeenAt) {
+      if (casparcg.connected) {
+        return {
+          level: "waiting" as const,
+          reason: "AMCP connected but no OSC packets are arriving",
+          fixLabel: "Open Server settings",
+          prefsTab: "server" as const,
+        };
+      }
+      if (casparcg.enabled) {
+        return {
+          level: "waiting" as const,
+          reason: "Waiting for the CasparCG server (AMCP not connected)",
+          fixLabel: "Open Server settings",
+          prefsTab: "server" as const,
+        };
+      }
+      return {
+        level: "unconfigured" as const,
+        reason: "No packets from CasparCG yet",
+        fixLabel: "Open Server settings",
+        prefsTab: "server" as const,
+      };
+    }
+    if (now - sources.ccgOsc.lastSeenAt > STALE_MS) {
+      return {
+        level: "offline" as const,
+        reason: "CasparCG OSC feed stopped",
+        prefsTab: "server" as const,
+      };
+    }
+    return READY;
+  })();
+
+  const ccgAmcp: Readiness = !casparcg.enabled
+    ? {
+        level: "unconfigured",
+        reason: "No CasparCG server address configured",
+        fixLabel: "Open Server settings",
+        prefsTab: "server",
+      }
+    : !casparcg.connected
+    ? {
+        level: "offline",
+        reason: `AMCP connection down${casparcg.lastError ? ` (${casparcg.lastError})` : ""}`,
+        prefsTab: "server",
+      }
+    : casparcg.latencyMs == null
+    ? {
+        level: "waiting",
+        reason: "Connected, waiting for the first PING reply",
+        fixLabel: "Open Server settings",
+        prefsTab: "server",
+      }
+    : READY;
+
+  return {
+    none: READY,
+    timezones:
+      timezoneClocks.length === 0
+        ? {
+            level: "unconfigured",
+            reason: "No timezones configured",
+            fixLabel: "Open Timezone settings",
+            prefsTab: "timezones",
+          }
+        : READY,
+    ccgOsc,
+    ccgAmcp,
+    ontime: udpFamily(
+      state.sources.ontime,
+      "Nothing received from Ontime on port {oscPort}",
+      "server"
+    ),
+    oscTimer: udpFamily(
+      state.sources.oscTimer,
+      "No /timer commands received on port {oscPort}",
+      "server"
+    ),
+    display: udpFamily(
+      state.sources.display,
+      "No /display values received on port {oscPort}",
+      "server"
+    ),
+    hyperdeck:
+      recorders.length === 0
+        ? {
+            level: "unconfigured",
+            reason: "No recorders configured",
+            fixLabel: "Open Recorder settings",
+            prefsTab: "recorders",
+          }
+        : READY,
+    x32: !x32.enabled
+      ? {
+          level: "unconfigured",
+          reason: "No mixer address configured",
+          fixLabel: "Open Mixer settings",
+          prefsTab: "mixer",
+        }
+      : !x32.connected
+      ? {
+          level: "offline",
+          reason: "No reply from the console",
+          prefsTab: "mixer",
+        }
+      : READY,
+  };
+}
+
+const TARGET_TIME_RE = /^\d{2}:\d{2}:\d{2}$/;
+
+export function getWidgetReadiness(
+  widgetKey: WidgetKind,
+  source: SourceId,
+  settings: WidgetSettings | undefined,
+  state: ReadinessState
+): Readiness {
+  // ccgHealth IS the status widget; its own faces are the honest state.
+  if (widgetKey === "ccgHealth") return READY;
+
+  // Per-widget broken references and invalid settings outrank source status:
+  // a widget pointing at a deleted resource is broken even if the source is up.
+  if (widgetKey === "worldClock") {
+    // No timezoneId is the explicit "Local time" choice; it needs nothing.
+    if (!settings?.timezoneId) return READY;
+    if (!state.timezoneClocks.some((tz) => tz.id === settings.timezoneId)) {
+      return {
+        level: "brokenRef",
+        reason: "Timezone no longer configured",
+        fixLabel: "Open Timezone settings",
+        prefsTab: "timezones",
+      };
+    }
+  }
+
+  if (
+    (widgetKey === "recorderStatus" || widgetKey === "recorderMedia") &&
+    settings?.recorderId &&
+    state.recorders.length > 0 &&
+    !state.recorders.some((r) => r.id === settings.recorderId)
+  ) {
+    return {
+      level: "brokenRef",
+      reason: "Recorder removed or disabled",
+      fixLabel: "Open Recorder settings",
+      prefsTab: "recorders",
+    };
+  }
+
+  if (
+    widgetKey === "timeOfDayCountdown" &&
+    // Mirrors the render fallback: an unset target means the 20:00:00 default.
+    !TARGET_TIME_RE.test(settings?.targetTime || "20:00:00")
+  ) {
+    // The fix is the widget's own input, so no deep-link button (empty label
+    // suppresses it in GuidedFace).
+    return {
+      level: "brokenRef",
+      reason: "Target must be zero-padded HH:MM:SS; edit it on the widget",
+      fixLabel: "",
+      prefsTab: "server",
+    };
+  }
+
+  const sourceStatus = getSourceStatus(state)[source];
+  if (sourceStatus.level !== "ready") return sourceStatus;
+
+  // The family is alive but this specific widget's name/key has never matched.
+  if (widgetKey === "oscTimer") {
+    const name = settings?.oscTimerName || "default";
+    if (!state.oscTimerNames.includes(name)) {
+      return {
+        level: "waiting",
+        reason: `Listening for /timer/${name}/start on port {oscPort}. Packets are arriving but none match this name (case sensitive).`,
+        fixLabel: "Open Server settings",
+        prefsTab: "server",
+      };
+    }
+  }
+
+  if (widgetKey === "displayTile") {
+    const key = settings?.displayKey || "value";
+    if (!(key in state.displayValues)) {
+      return {
+        level: "waiting",
+        reason: `No value for key "${key}" yet. Send /display/${key} <value> to port {oscPort} (case sensitive).`,
+        fixLabel: "Open Server settings",
+        prefsTab: "server",
+      };
+    }
+  }
+
+  return READY;
+}
+
+/** Telemetry backing a source, for the guided face's "last packet" line. */
+export function sourceTelemetry(
+  source: SourceId,
+  state: ReadinessState
+): SourceTelemetry | null {
+  switch (source) {
+    case "ccgOsc":
+      return state.sources.ccgOsc;
+    case "ontime":
+      return state.sources.ontime;
+    case "oscTimer":
+      return state.sources.oscTimer;
+    case "display":
+      return state.sources.display;
+    default:
+      return null;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,12 @@ body {
   animation: blink-red 1s linear infinite;
 }
 
+@keyframes blink-red {
+  50% {
+    opacity: 0.15;
+  }
+}
+
 .blink {
   animation: blink-animation 2s cubic-bezier(0.075, 0.82, 0.165, 1) infinite;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,6 +394,10 @@ const createWindow = (): void => {
       ccgFormat: osc.channelFormat,
       ccgFramerate: osc.channelFramerate,
       displayValues: osc.getDisplayValues(),
+      sources: {
+        ...osc.getSourcesSnapshot(),
+        oscPort: store.get("server").port,
+      },
       elapsedColor: store.get("colors.elapsed"),
       remainingColor: store.get("colors.remaining"),
       clockColor: store.get("colors.clock"),

--- a/src/osc.ts
+++ b/src/osc.ts
@@ -3,6 +3,21 @@ import store from "./store";
 
 type TimerAction = "start" | "stop" | "reset" | "toggle" | "set";
 
+export type SourceTelemetry = {
+  /** Epoch ms of the last packet in this address family; 0 = never. */
+  lastSeenAt: number;
+  lastSender: string;
+};
+
+export type OscSourcesSnapshot = {
+  ccgOsc: SourceTelemetry;
+  ontime: SourceTelemetry;
+  oscTimer: SourceTelemetry;
+  display: SourceTelemetry;
+};
+
+const emptyTelemetry = (): SourceTelemetry => ({ lastSeenAt: 0, lastSender: "" });
+
 class oscListener {
   port: number;
   currentTime: number;
@@ -25,6 +40,7 @@ class oscListener {
   foregroundSeenAt: number;
   backgroundSeenAt: number;
   displayValues: Map<string, string>;
+  sources: OscSourcesSnapshot;
   udpPort: UDPPort | undefined;
   onLayoutLoad?: (layoutName: string) => void;
   onTimerCommand?: (name: string, action: TimerAction, value?: number) => void;
@@ -53,6 +69,12 @@ class oscListener {
     this.foregroundSeenAt = 0;
     this.backgroundSeenAt = 0;
     this.displayValues = new Map();
+    this.sources = {
+      ccgOsc: emptyTelemetry(),
+      ontime: emptyTelemetry(),
+      oscTimer: emptyTelemetry(),
+      display: emptyTelemetry(),
+    };
     this.udpPort = undefined;
     this.onLayoutLoad = onLayoutLoad;
     this.onTimerCommand = onTimerCommand;
@@ -72,7 +94,7 @@ class oscListener {
 
     
 
-    this.udpPort.on("message", (message: OSCMessage) => {
+    this.udpPort.on("message", (message: OSCMessage, _timetag?: unknown, info?: unknown) => {
       if (message["address"] === "/layout/load" || message["address"] === "/layout/select") {
         const [firstArg] = message["args"] || [];
         if (typeof firstArg?.value === "string" && this.onLayoutLoad) {
@@ -83,22 +105,28 @@ class oscListener {
 
       // Handle timer commands: /timer/{name}/{action}
       if (message["address"].startsWith("/timer/")) {
+        this.stamp("oscTimer", info);
         this.parseTimerCommand(message);
         return;
       }
 
       // Handle display tiles: /display/{key} <value...>
       if (message["address"].startsWith("/display/")) {
+        this.stamp("display", info);
         this.parseDisplayMessage(message);
         return;
       }
 
-      // If the message startes with /channel/ then it is a CCG message
+      // If the message startes with /channel/ then it is a CCG message.
+      // Liveness is stamped for ANY channel so a wrong-channel setting still
+      // reads as "feed alive" rather than "server down".
       if (message["address"].startsWith("/channel/")) {
+        this.stamp("ccgOsc", info);
         this.parseCCGMessage(message);
       }
 
       if (message["address"].startsWith("/from-ontime/")) {
+        this.stamp("ontime", info);
         this.parseOntimeMessage(message);
       }
 
@@ -272,6 +300,22 @@ class oscListener {
     return Object.fromEntries(this.displayValues);
   };
 
+  private stamp = (family: keyof OscSourcesSnapshot, info: unknown) => {
+    const telemetry = this.sources[family];
+    telemetry.lastSeenAt = Date.now();
+    const sender = (info as { address?: string } | undefined)?.address;
+    if (sender) telemetry.lastSender = sender;
+  };
+
+  public getSourcesSnapshot = (): OscSourcesSnapshot => {
+    return {
+      ccgOsc: { ...this.sources.ccgOsc },
+      ontime: { ...this.sources.ontime },
+      oscTimer: { ...this.sources.oscTimer },
+      display: { ...this.sources.display },
+    };
+  };
+
   private parseTimerCommand = (message: OSCMessage) => {
     if (!this.onTimerCommand) return;
 
@@ -324,6 +368,14 @@ class oscListener {
     this.foregroundSeenAt = 0;
     this.backgroundSeenAt = 0;
     this.displayValues.clear();
+    // The listener restarts on any Server change (possibly a new port), so
+    // stale liveness stamps from the old socket would mislead the readiness UI.
+    this.sources = {
+      ccgOsc: emptyTelemetry(),
+      ontime: emptyTelemetry(),
+      oscTimer: emptyTelemetry(),
+      display: emptyTelemetry(),
+    };
   };
 
   /**


### PR DESCRIPTION
Adds a self-serve answer to "what does this widget do, and why is it empty?" without touching run mode.

## What users see

- Every widget card in edit mode gains a **?** button next to the split/color/remove actions. It opens a help dialog with:
  - the widget's description and a "How to read it" section decoding its states (frozen values, dashes, blinks, latching behavior),
  - **live source status**: not configured / configured but silent / offline / broken reference, with the socket error where known and a "Last packet: 3 s ago from 192.168.1.10" line for OSC sources,
  - numbered setup steps (shared per-integration plumbing plus widget-specific hints, with the actual configured OSC port interpolated, never hardcoded),
  - an **Open settings** button that deep-links to the right Preferences tab.
- The **?** icon tints amber when the source needs setup and red when it is offline or references a deleted timezone/recorder, so problems stay visible at a glance while the explanation stays behind a click.

## Under the hood

- `WidgetDefinition` now requires `source`, `setupHint`, and `reading`; adding a widget kind without help copy is a compile error. All 24 widgets carry copy verified against the render code (from the widget inventory in `docs/widget-help-design.md`, kept untracked).
- New `src/app/lib/widget-readiness.ts`: every readiness predicate and every reason/fix string lives in one module, so wording cannot drift per widget. Detection includes the CasparCG 2.3 signature (AMCP connected but no OSC flowing), 3 s UDP staleness, and per-widget name/key mismatch for OSC timers and variable tiles (case sensitivity is the top footgun).
- The OSC listener stamps per-family `lastSeenAt`/`lastSender` telemetry (CasparCG channels, Ontime, `/timer`, `/display`), reset on listener restart, shipped as `sources` in the `timers:update` payload.
- Per-widget edit controls (timezone picker, timer name, recorder/channel pickers) were extracted into shared helpers along the way.

## Bug fixes surfaced by the inventory

- The `blink-red` CSS animation was referenced but never defined, so the Next Clip urgency blink, Server Health OFFLINE blink, and Ontime On-Air blink were silent no-ops. Now defined.
- World Clock's "Local time" option showed the first configured timezone instead of local time; it now renders true local time, and a deleted timezone shows a broken-reference state instead of silently swapping zones.
- Recorder widgets silently fell back to the first deck when their configured recorder was deleted or disabled, which could show a different machine's status on air. They now show a dash with the broken reference flagged in the help dialog.

## Verification

`tsc`, `eslint`, and `electron-vite build` pass. The readiness module is covered by 26 predicate checks (unconfigured/waiting/offline/brokenRef per source, per-widget overrides, interpolation, last-packet formatting), all passing.